### PR TITLE
AArch64: Introduce new functions for generating instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
+++ b/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
@@ -39,7 +39,7 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
     //
     swapInstructionListsWithCompilation();
 
-    TR::Instruction *entryLabelInstruction = generateLabelInstruction(_cg, OP::label, _callNode, _entryLabel);
+    TR::Instruction *entryLabelInstruction = Inst_Label(_cg, OP::label, _callNode, _entryLabel);
 
     _cg->incOutOfLineColdPathNestedDepth();
     TR_Debug *debugObj = _cg->getDebug();
@@ -51,11 +51,11 @@ void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
 
     if (_targetReg) {
         TR_ASSERT(resultReg, "resultReg must not be a NULL");
-        generateMovInstruction(_cg, _callNode, _targetReg, resultReg);
+        Inst_Mov(_cg, _callNode, _targetReg, resultReg);
     }
     _cg->decReferenceCount(_callNode);
 
-    TR::Instruction *returnBranchInstruction = generateLabelInstruction(_cg, OP::b, _callNode, _restartLabel);
+    TR::Instruction *returnBranchInstruction = Inst_Label(_cg, OP::b, _callNode, _restartLabel);
 
     if (debugObj) {
         debugObj->addInstructionComment(returnBranchInstruction, "Denotes end of OOL: return to mainline");

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -442,7 +442,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
     uint32_t frameSize = (uint32_t)cg->getFrameSizeInBytes();
     if (frameSize > 0) {
         if (constantIsUnsignedImm12(frameSize)) {
-            cursor = generateTrg1Src1ImmInstruction(cg, OP::subimmx, firstNode, sp, sp, frameSize, cursor);
+            cursor = Inst_Trg1Src1Imm(cg, OP::subimmx, firstNode, sp, sp, frameSize, cursor);
         } else {
             TR_UNIMPLEMENTED();
         }
@@ -451,7 +451,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
     // save link register (x30)
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = MRef_disp(cg, sp, 0);
-        cursor = generateMemSrc1Instruction(this->cg(), OP::strimmx, firstNode, stackSlot,
+        cursor = Inst_MemSrc1(this->cg(), OP::strimmx, firstNode, stackSlot,
             machine->getRealRegister(TR::RealRegister::x30), cursor);
     }
 
@@ -461,7 +461,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateMemSrc1Instruction(this->cg(), OP::strimmx, firstNode, stackSlot, rr, cursor);
+            cursor = Inst_MemSrc1(this->cg(), OP::strimmx, firstNode, stackSlot, rr, cursor);
             offset += 8;
         }
     }
@@ -469,7 +469,7 @@ void TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Pa
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateMemSrc1Instruction(this->cg(), OP::vstrimmq, firstNode, stackSlot, rr, cursor);
+            cursor = Inst_MemSrc1(this->cg(), OP::vstrimmq, firstNode, stackSlot, rr, cursor);
             offset += 16;
         }
     }
@@ -491,7 +491,7 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateTrg1MemInstruction(this->cg(), OP::ldrimmx, lastNode, rr, stackSlot, cursor);
+            cursor = Inst_Trg1Mem(this->cg(), OP::ldrimmx, lastNode, rr, stackSlot, cursor);
             offset += 8;
         }
     }
@@ -499,7 +499,7 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
         TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
         if (rr->getHasBeenAssignedInMethod()) {
             TR::MemoryReference *stackSlot = MRef_disp(cg, sp, offset);
-            cursor = generateTrg1MemInstruction(this->cg(), OP::vldrimmq, lastNode, rr, stackSlot, cursor);
+            cursor = Inst_Trg1Mem(this->cg(), OP::vldrimmq, lastNode, rr, stackSlot, cursor);
             offset += 16;
         }
     }
@@ -508,21 +508,21 @@ void TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
     TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
     if (machine->getLinkRegisterKilled()) {
         TR::MemoryReference *stackSlot = MRef_disp(cg, sp, 0);
-        cursor = generateTrg1MemInstruction(this->cg(), OP::ldrimmx, lastNode, lr, stackSlot, cursor);
+        cursor = Inst_Trg1Mem(this->cg(), OP::ldrimmx, lastNode, lr, stackSlot, cursor);
     }
 
     // remove space for preserved registers
     uint32_t frameSize = cg->getFrameSizeInBytes();
     if (frameSize > 0) {
         if (constantIsUnsignedImm12(frameSize)) {
-            cursor = generateTrg1Src1ImmInstruction(cg, OP::addimmx, lastNode, sp, sp, frameSize, cursor);
+            cursor = Inst_Trg1Src1Imm(cg, OP::addimmx, lastNode, sp, sp, frameSize, cursor);
         } else {
             TR_UNIMPLEMENTED();
         }
     }
 
     // return
-    cursor = generateRegBranchInstruction(cg, OP::ret, lastNode, lr, cursor);
+    cursor = Inst_RegBranch(cg, OP::ret, lastNode, lr, cursor);
 }
 
 int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies)
@@ -640,7 +640,7 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
                             tempReg = cg()->allocateCollectedReferenceRegister();
                         else
                             tempReg = cg()->allocateRegister();
-                        generateMovInstruction(cg(), callNode, tempReg, argRegister);
+                        Inst_Mov(cg(), callNode, tempReg, argRegister);
                         argRegister = tempReg;
                     }
                     if (numIntegerArgs == 0 && (resType.isAddress() || resType.isInt32() || resType.isInt64())) {
@@ -692,7 +692,7 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
                     if (!cg()->canClobberNodesRegister(child, 0)) {
                         tempReg = cg()->allocateRegister(TR_FPR);
                         op = (childType == TR::Float) ? OP::fmovs : OP::fmovd;
-                        generateTrg1Src1Instruction(cg(), op, callNode, tempReg, argRegister);
+                        Inst_Trg1Src1(cg(), op, callNode, tempReg, argRegister);
                         argRegister = tempReg;
                     }
                     if ((numFloatArgs == 0 && resType.isFloatingPoint())) {
@@ -774,12 +774,11 @@ int32_t TR::ARM64SystemLinkage::buildArgs(TR::Node *callNode, TR::RegisterDepend
 
     if (numMemArgs > 0) {
         TR::RealRegister *sp = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
-        generateTrg1Src1ImmInstruction(cg(), OP::subimmx, callNode, argMemReg, sp, totalSize);
+        Inst_Trg1Src1Imm(cg(), OP::subimmx, callNode, argMemReg, sp, totalSize);
 
         for (argIndex = 0; argIndex < numMemArgs; argIndex++) {
             TR::Register *aReg = pushToMemory[argIndex].argRegister;
-            generateMemSrc1Instruction(cg(), pushToMemory[argIndex].opCode, callNode, pushToMemory[argIndex].argMemory,
-                aReg);
+            Inst_MemSrc1(cg(), pushToMemory[argIndex].opCode, callNode, pushToMemory[argIndex].argMemory, aReg);
             cg()->stopUsingRegister(aReg);
         }
 
@@ -804,21 +803,21 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
     int32_t totalSize = buildArgs(callNode, dependencies);
     if (totalSize > 0) {
         if (constantIsUnsignedImm12(totalSize)) {
-            generateTrg1Src1ImmInstruction(cg(), OP::subimmx, callNode, sp, sp, totalSize);
+            Inst_Trg1Src1Imm(cg(), OP::subimmx, callNode, sp, sp, totalSize);
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }
     }
 
     TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
-    generateImmSymInstruction(cg(), OP::bl, callNode, (uintptr_t)callSymbol->getMethodAddress(), dependencies,
+    Inst_ImmSym(cg(), OP::bl, callNode, (uintptr_t)callSymbol->getMethodAddress(), dependencies,
         callSymRef ? callSymRef : callNode->getSymbolReference(), NULL);
 
     cg()->machine()->setLinkRegisterKilled(true);
 
     if (totalSize > 0) {
         if (constantIsUnsignedImm12(totalSize)) {
-            generateTrg1Src1ImmInstruction(cg(), OP::addimmx, callNode, sp, sp, totalSize);
+            Inst_Trg1Src1Imm(cg(), OP::addimmx, callNode, sp, sp, totalSize);
         } else {
             TR_ASSERT_FATAL(false, "Too many arguments.");
         }

--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -81,7 +81,7 @@ static inline TR::Register *genericBinaryEvaluator(TR::Node *node, OP::Mnemonic 
         }
         /* When regOp == regOpImm, an immediate version of the instruction does not exist. */
         if ((constantIsUnsignedImm12(value) || constantIsUnsignedImm12Shifted(value)) && regOp != regOpImm) {
-            generateTrg1Src1ImmInstruction(cg, regOpImm, node, trgReg, src1Reg, value);
+            Inst_Trg1Src1Imm(cg, regOpImm, node, trgReg, src1Reg, value);
         } else if ((constantIsUnsignedImm12(-value) || constantIsUnsignedImm12Shifted(-value))
             && (regOpImm == OP::addimmw || regOpImm == OP::addimmx || regOpImm == OP::subimmw
                 || regOpImm == OP::subimmx)) {
@@ -102,7 +102,7 @@ static inline TR::Register *genericBinaryEvaluator(TR::Node *node, OP::Mnemonic 
                 default:
                     TR_ASSERT(false, "Unsupported op");
             }
-            generateTrg1Src1ImmInstruction(cg, negatedOp, node, trgReg, src1Reg, -value);
+            Inst_Trg1Src1Imm(cg, negatedOp, node, trgReg, src1Reg, -value);
         } else {
             OP::Mnemonic negatedOp = OP::bad;
 
@@ -134,16 +134,16 @@ static inline TR::Register *genericBinaryEvaluator(TR::Node *node, OP::Mnemonic 
                 } else {
                     loadConstant32(cg, node, -value, src2Reg);
                 }
-                generateTrg1Src2Instruction(cg, negatedOp, node, trgReg, src1Reg, src2Reg);
+                Inst_Trg1Src2(cg, negatedOp, node, trgReg, src1Reg, src2Reg);
                 cg->stopUsingRegister(src2Reg);
             } else {
                 src2Reg = cg->evaluate(secondChild);
-                generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
+                Inst_Trg1Src2(cg, regOp, node, trgReg, src1Reg, src2Reg);
             }
         }
     } else {
         src2Reg = cg->evaluate(secondChild);
-        generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
+        Inst_Trg1Src2(cg, regOp, node, trgReg, src1Reg, src2Reg);
     }
 
     node->setRegister(trgReg);
@@ -190,7 +190,7 @@ static TR::Register *generateMaddOrMsub(TR::Node *node, TR::Node *mulNode, TR::N
             }
         }
 
-        generateTrg1Src3Instruction(cg, op, node, trgReg, mulSrc1Reg, mulSrc2Reg, src3Reg);
+        Inst_Trg1Src3(cg, op, node, trgReg, mulSrc1Reg, mulSrc2Reg, src3Reg);
 
         node->setRegister(trgReg);
         cg->decReferenceCount(mulFirstChild);
@@ -342,10 +342,9 @@ static TR::Register *generateShiftedBinaryOperation(TR::Node *node, OP::Mnemonic
                 ? TR::SH_LSL
                 : (shiftNode->getOpCode().isShiftLogical() ? TR::SH_LSR : TR::SH_ASR));
 
-        generateTrg1Src2ShiftedInstruction(cg, (notNode == NULL) ? op : notOp, node, treg, s1reg, s2reg, code,
-            shiftValue);
+        Inst_Trg1Src2Shifted(cg, (notNode == NULL) ? op : notOp, node, treg, s1reg, s2reg, code, shiftValue);
     } else {
-        generateTrg1Src2Instruction(cg, (notNode == NULL) ? op : notOp, node, treg, s1reg, s2reg);
+        Inst_Trg1Src2(cg, (notNode == NULL) ? op : notOp, node, treg, s1reg, s2reg);
     }
 
     node->setRegister(treg);
@@ -459,7 +458,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, lhsReg, rhsReg, cg);
     } else {
-        generateTrg1Src2Instruction(cg, op, node, resReg, lhsReg, rhsReg);
+        Inst_Trg1Src2(cg, op, node, resReg, lhsReg, rhsReg);
     }
 
     cg->decReferenceCount(firstChild);
@@ -553,23 +552,23 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmulInt64Helper(TR::Node *node, TR::Reg
     TR::Register *tmp2Reg = cg->allocateRegister(TR_VRF);
 
     /* Reverse 32bit words in 64bit elements */
-    generateTrg1Src1Instruction(cg, OP::vrev64_4s, node, tmp1Reg, lhsReg);
+    Inst_Trg1Src1(cg, OP::vrev64_4s, node, tmp1Reg, lhsReg);
 
-    generateTrg1Src2Instruction(cg, OP::vmul4s, node, tmp2Reg, tmp1Reg, rhsReg);
+    Inst_Trg1Src2(cg, OP::vmul4s, node, tmp2Reg, tmp1Reg, rhsReg);
     /*
      * At this moment, upper 32bit of each 64-bit element of tmp2Reg is A*D, lower 32bit is B*C.
      * Get A*D + B*C into the lower 32bit.
      */
-    generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, tmp1Reg, tmp2Reg, 32);
-    generateTrg1Src2Instruction(cg, OP::vadd4s, node, tmp2Reg, tmp1Reg, tmp2Reg);
+    Inst_VectorShiftImmediate(cg, OP::vushr2d, node, tmp1Reg, tmp2Reg, 32);
+    Inst_Trg1Src2(cg, OP::vadd4s, node, tmp2Reg, tmp1Reg, tmp2Reg);
     /* Shift left by 32bit to have the result in the upper 32bit part. */
-    generateVectorShiftImmediateInstruction(cg, OP::vshl2d, node, productReg, tmp2Reg, 32);
+    Inst_VectorShiftImmediate(cg, OP::vshl2d, node, productReg, tmp2Reg, 32);
 
     /* Move the lower 32-bit of the second element to the upper 32-bit of the first element. */
-    generateTrg1Src2Instruction(cg, OP::vuzp1_4s, node, tmp1Reg, lhsReg, lhsReg);
-    generateTrg1Src2Instruction(cg, OP::vuzp1_4s, node, tmp2Reg, rhsReg, rhsReg);
+    Inst_Trg1Src2(cg, OP::vuzp1_4s, node, tmp1Reg, lhsReg, lhsReg);
+    Inst_Trg1Src2(cg, OP::vuzp1_4s, node, tmp2Reg, rhsReg, rhsReg);
     /* Finally, get the result by UMLAL. */
-    generateTrg1Src2Instruction(cg, OP::vumlal_2d, node, productReg, tmp1Reg, tmp2Reg);
+    Inst_Trg1Src2(cg, OP::vumlal_2d, node, productReg, tmp1Reg, tmp2Reg);
 
     cg->stopUsingRegister(tmp1Reg);
     cg->stopUsingRegister(tmp2Reg);
@@ -696,24 +695,20 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
         TR::Register *counterReg = srm->findOrCreateScratchRegister(TR_GPR);
         TR::Register *tmp1VectorReg = srm->findOrCreateScratchRegister(TR_VRF);
         TR::Register *tmp2VectorReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, OP::vorr16b, node, tmp1VectorReg, lhsReg, lhsReg);
-        generateTrg1Src2Instruction(cg, OP::vorr16b, node, tmp2VectorReg, rhsReg, rhsReg);
+        Inst_Trg1Src2(cg, OP::vorr16b, node, tmp1VectorReg, lhsReg, lhsReg);
+        Inst_Trg1Src2(cg, OP::vorr16b, node, tmp2VectorReg, rhsReg, rhsReg);
         loadConstant32(cg, node, loopCount, counterReg);
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
-        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, resultReg, resultReg,
-            (eType == TR::Int8) ? 8 : 16);
+        Inst_Label(cg, OP::label, node, loopLabel);
+        Inst_VectorShiftImmediate(cg, OP::vushr4s, node, resultReg, resultReg, (eType == TR::Int8) ? 8 : 16);
         for (int32_t i = 0; i < numElementsPerLoop; i++) {
-            generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp1Reg, tmp1VectorReg, i * loopCount);
-            generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp2Reg, tmp2VectorReg, i * loopCount);
-            generateTrg1Src2Instruction(cg, op.divOp, node, tmp1Reg, tmp1Reg, tmp2Reg);
-            generateMovGPRToVectorElementInstruction(cg, op.gprToVectorOp, node, resultReg, tmp1Reg,
-                (i + 1) * loopCount - 1);
+            Inst_MovVectorElementToGPR(cg, op.vectorToGPROp, node, tmp1Reg, tmp1VectorReg, i * loopCount);
+            Inst_MovVectorElementToGPR(cg, op.vectorToGPROp, node, tmp2Reg, tmp2VectorReg, i * loopCount);
+            Inst_Trg1Src2(cg, op.divOp, node, tmp1Reg, tmp1Reg, tmp2Reg);
+            Inst_MovGPRToVectorElement(cg, op.gprToVectorOp, node, resultReg, tmp1Reg, (i + 1) * loopCount - 1);
         }
-        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, tmp1VectorReg, tmp1VectorReg,
-            (eType == TR::Int8) ? 8 : 16);
-        generateVectorShiftImmediateInstruction(cg, OP::vushr4s, node, tmp2VectorReg, tmp2VectorReg,
-            (eType == TR::Int8) ? 8 : 16);
-        generateTrg1Src1ImmInstruction(cg, OP::subimmw, node, counterReg, counterReg, 1);
+        Inst_VectorShiftImmediate(cg, OP::vushr4s, node, tmp1VectorReg, tmp1VectorReg, (eType == TR::Int8) ? 8 : 16);
+        Inst_VectorShiftImmediate(cg, OP::vushr4s, node, tmp2VectorReg, tmp2VectorReg, (eType == TR::Int8) ? 8 : 16);
+        Inst_Trg1Src1Imm(cg, OP::subimmw, node, counterReg, counterReg, 1);
 
         auto *cond = RegDeps(0, 3 + srm->numAvailableRegisters(), cg);
         cond->addPostCondition(lhsReg, TR::RealRegister::NoReg);
@@ -721,13 +716,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::vdivIntHelper(TR::Node *node, TR::Regis
         cond->addPostCondition(resultReg, TR::RealRegister::NoReg);
         srm->addScratchRegistersToDependencyList(cond);
 
-        generateCompareBranchInstruction(cg, OP::cbnzw, node, counterReg, loopLabel, cond);
+        Inst_CompareBranch(cg, OP::cbnzw, node, counterReg, loopLabel, cond);
     } else {
         for (int32_t i = 0; i < numElementsPerLoop; i++) {
-            generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp1Reg, lhsReg, i);
-            generateMovVectorElementToGPRInstruction(cg, op.vectorToGPROp, node, tmp2Reg, rhsReg, i);
-            generateTrg1Src2Instruction(cg, op.divOp, node, tmp1Reg, tmp1Reg, tmp2Reg);
-            generateMovGPRToVectorElementInstruction(cg, op.gprToVectorOp, node, resultReg, tmp1Reg, i);
+            Inst_MovVectorElementToGPR(cg, op.vectorToGPROp, node, tmp1Reg, lhsReg, i);
+            Inst_MovVectorElementToGPR(cg, op.vectorToGPROp, node, tmp2Reg, rhsReg, i);
+            Inst_Trg1Src2(cg, op.divOp, node, tmp1Reg, tmp1Reg, tmp2Reg);
+            Inst_MovGPRToVectorElement(cg, op.gprToVectorOp, node, resultReg, tmp1Reg, i);
         }
     }
 
@@ -856,8 +851,8 @@ static TR::Register *vminmaxInt64Helper(TR::Node *node, bool isMax, TR::Register
     TR_ASSERT_FATAL_WITH_NODE(node, lhsReg->getKind() == TR_VRF, "unexpected Register kind");
     TR_ASSERT_FATAL_WITH_NODE(node, rhsReg->getKind() == TR_VRF, "unexpected Register kind");
 
-    generateTrg1Src2Instruction(cg, OP::vcmge2d, node, resReg, lhsReg, rhsReg);
-    generateTrg1Src2Instruction(cg, OP::vbsl16b, node, resReg, (isMax ? lhsReg : rhsReg), (isMax ? rhsReg : lhsReg));
+    Inst_Trg1Src2(cg, OP::vcmge2d, node, resReg, lhsReg, rhsReg);
+    Inst_Trg1Src2(cg, OP::vbsl16b, node, resReg, (isMax ? lhsReg : rhsReg), (isMax ? rhsReg : lhsReg));
 
     return resReg;
 }
@@ -956,13 +951,13 @@ static void mulConstant32(TR::Node *node, TR::Register *treg, TR::Register *sreg
     if (value == 0) {
         loadConstant32(cg, node, 0, treg);
     } else if (value == 1) {
-        generateMovInstruction(cg, node, treg, sreg, false);
+        Inst_Mov(cg, node, treg, sreg, false);
     } else if (value == -1) {
-        generateNegInstruction(cg, node, treg, sreg, false);
+        Inst_Neg(cg, node, treg, sreg, false);
     } else {
         TR::Register *tmpReg = cg->allocateRegister();
         loadConstant32(cg, node, value, tmpReg);
-        generateMulInstruction(cg, node, treg, sreg, tmpReg);
+        Inst_Mul(cg, node, treg, sreg, tmpReg);
         cg->stopUsingRegister(tmpReg);
     }
 }
@@ -973,13 +968,13 @@ static void mulConstant64(TR::Node *node, TR::Register *treg, TR::Register *sreg
     if (value == 0) {
         loadConstant64(cg, node, 0, treg);
     } else if (value == 1) {
-        generateMovInstruction(cg, node, treg, sreg, true);
+        Inst_Mov(cg, node, treg, sreg, true);
     } else if (value == -1) {
-        generateNegInstruction(cg, node, treg, sreg, true);
+        Inst_Neg(cg, node, treg, sreg, true);
     } else {
         TR::Register *tmpReg = cg->allocateRegister();
         loadConstant64(cg, node, value, tmpReg);
-        generateMulInstruction(cg, node, treg, sreg, tmpReg);
+        Inst_Mul(cg, node, treg, sreg, tmpReg);
         cg->stopUsingRegister(tmpReg);
     }
 }
@@ -1013,7 +1008,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeG
         mulConstant32(node, trgReg, src1Reg, value, cg);
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
+        Inst_Mul(cg, node, trgReg, src1Reg, src2Reg);
     }
 
     node->setRegister(trgReg);
@@ -1044,10 +1039,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
         src2Reg = cg->evaluate(secondChild);
     }
 
-    generateTrg1Src3Instruction(cg, OP::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg);
+    Inst_Trg1Src3(cg, OP::smaddl, node, trgReg, src1Reg, src2Reg, zeroReg);
     cg->stopUsingRegister(zeroReg);
     /* logical shift right by 32 bits */
-    generateLogicalShiftRightImmInstruction(cg, node, trgReg, trgReg, 32, true);
+    Inst_LogicalShiftRightImm(cg, node, trgReg, trgReg, 32, true);
 
     if (tmpReg) {
         cg->stopUsingRegister(tmpReg);
@@ -1088,7 +1083,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeG
         mulConstant64(node, trgReg, src1Reg, value, cg);
     } else {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateMulInstruction(cg, node, trgReg, src1Reg, src2Reg);
+        Inst_Mul(cg, node, trgReg, src1Reg, src2Reg);
     }
 
     node->setRegister(trgReg);
@@ -1107,7 +1102,7 @@ static TR::Register *idivHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     TR::Register *src2Reg = cg->evaluate(secondChild);
     TR::Register *trgReg = cg->allocateRegister();
 
-    generateTrg1Src2Instruction(cg, is64bit ? OP::sdivx : OP::sdivw, node, trgReg, src1Reg, src2Reg);
+    Inst_Trg1Src2(cg, is64bit ? OP::sdivx : OP::sdivw, node, trgReg, src1Reg, src2Reg);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -1127,8 +1122,8 @@ static TR::Register *iremHelper(TR::Node *node, bool is64bit, bool isUnsigned, T
     TR::Register *trgReg = cg->allocateRegister();
 
     OP::Mnemonic op = is64bit ? (isUnsigned ? OP::udivx : OP::sdivx) : (isUnsigned ? OP::udivw : OP::sdivw);
-    generateTrg1Src2Instruction(cg, op, node, tmpReg, src1Reg, src2Reg);
-    generateTrg1Src3Instruction(cg, is64bit ? OP::msubx : OP::msubw, node, trgReg, tmpReg, src2Reg, src1Reg);
+    Inst_Trg1Src2(cg, op, node, tmpReg, src1Reg, src2Reg);
+    Inst_Trg1Src3(cg, is64bit ? OP::msubx : OP::msubw, node, trgReg, tmpReg, src2Reg, src1Reg);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -1156,7 +1151,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
         src2Reg = cg->evaluate(secondChild);
     }
 
-    generateTrg1Src2Instruction(cg, OP::smulh, node, trgReg, src1Reg, src2Reg);
+    Inst_Trg1Src2(cg, OP::smulh, node, trgReg, src1Reg, src2Reg);
 
     if (tmpReg) {
         cg->stopUsingRegister(tmpReg);
@@ -1178,10 +1173,10 @@ static TR::Register *subInt32DivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
     TR::Register *trgReg = cg->allocateRegister();
     const uint32_t operandBits = TR::DataType::getSize(node->getDataType()) * 8;
 
-    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, src1Reg, operandBits - 1); // sxtb or sxth
-    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, tmpReg, src2Reg, operandBits - 1); // sxtb or sxth
+    Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, src1Reg, operandBits - 1); // sxtb or sxth
+    Inst_Trg1Src1Imm(cg, OP::sbfmw, node, tmpReg, src2Reg, operandBits - 1); // sxtb or sxth
 
-    generateTrg1Src2Instruction(cg, OP::sdivw, node, trgReg, trgReg, tmpReg);
+    Inst_Trg1Src2(cg, OP::sdivw, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -1286,7 +1281,7 @@ static TR::Register *generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGe
              * The result is always 0 in this case.
              */
             TR::Register *reg = cg->allocateRegister();
-            generateTrg1ImmInstruction(cg, OP::movzx, shiftNode, reg, 0);
+            Inst_Trg1Imm(cg, OP::movzx, shiftNode, reg, 0);
             shiftNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(andNode);
             cg->decReferenceCount(shiftValueNode);
@@ -1313,7 +1308,7 @@ static TR::Register *generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGe
                 reg = cg->allocateRegister();
             }
 
-            generateUBFIZInstruction(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
+            Inst_UBFIZ(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
             shiftNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(andNode);
             cg->decReferenceCount(shiftValueNode);
@@ -1345,21 +1340,21 @@ static TR::Register *generateUBFMForMaskAndShift(TR::Node *shiftNode, TR::CodeGe
                 TR::Register *shiftSrcReg = sreg;
                 if (shiftNode->getOpCode().isShiftLogical()) {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, andNode, reg, sreg,
+                        Inst_Trg1Src1Imm(cg, OP::ubfmw, andNode, reg, sreg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = reg;
                     }
-                    generateLogicalShiftRightImmInstruction(cg, shiftNode, reg, shiftSrcReg, shiftValue, is64bit);
+                    Inst_LogicalShiftRightImm(cg, shiftNode, reg, shiftSrcReg, shiftValue, is64bit);
                 } else {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, andNode, reg, sreg,
+                        Inst_Trg1Src1Imm(cg, OP::sbfmw, andNode, reg, sreg,
                             operandBits - 1); // sxth or sxtb
                         shiftSrcReg = reg;
                     }
-                    generateArithmeticShiftRightImmInstruction(cg, shiftNode, reg, shiftSrcReg, shiftValue, is64bit);
+                    Inst_ArithmeticShiftRightImm(cg, shiftNode, reg, shiftSrcReg, shiftValue, is64bit);
                 }
             } else {
-                generateUBFXInstruction(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
+                Inst_UBFX(cg, shiftNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
             }
             shiftNode->setRegister(reg);
             cg->recursivelyDecReferenceCount(andNode);
@@ -1390,7 +1385,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
                 trgReg = srcReg;
             } else {
                 trgReg = cg->allocateRegister();
-                generateMovInstruction(cg, node, trgReg, srcReg, is64bit);
+                Inst_Mov(cg, node, trgReg, srcReg, is64bit);
             }
         } else {
             uint32_t shift = is64bit ? (value & 0x3F) : (value & 0x1F);
@@ -1399,23 +1394,23 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
 
             switch (shiftType) {
                 case TR::SH_LSL:
-                    generateLogicalShiftLeftImmInstruction(cg, node, trgReg, shiftSrcReg, shift, is64bit);
+                    Inst_LogicalShiftLeftImm(cg, node, trgReg, shiftSrcReg, shift, is64bit);
                     break;
                 case TR::SH_LSR:
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, node, trgReg, srcReg,
+                        Inst_Trg1Src1Imm(cg, OP::ubfmw, node, trgReg, srcReg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = trgReg;
                     }
-                    generateLogicalShiftRightImmInstruction(cg, node, trgReg, shiftSrcReg, shift, is64bit);
+                    Inst_LogicalShiftRightImm(cg, node, trgReg, shiftSrcReg, shift, is64bit);
                     break;
                 case TR::SH_ASR:
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg,
+                        Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, srcReg,
                             operandBits - 1); // sxth or sxtb
                         shiftSrcReg = trgReg;
                     }
-                    generateArithmeticShiftRightImmInstruction(cg, node, trgReg, shiftSrcReg, shift, is64bit);
+                    Inst_ArithmeticShiftRightImm(cg, node, trgReg, shiftSrcReg, shift, is64bit);
                     break;
                 default:
                     TR_ASSERT(false, "Unsupported shift type.");
@@ -1433,7 +1428,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
             case TR::SH_LSR:
                 op = is64bit ? OP::lsrvx : OP::lsrvw;
                 if (operandBits < 32) {
-                    generateTrg1Src1ImmInstruction(cg, OP::ubfmw, node, trgReg, srcReg,
+                    Inst_Trg1Src1Imm(cg, OP::ubfmw, node, trgReg, srcReg,
                         operandBits - 1); // uxth or uxtb
                     shiftSrcReg = trgReg;
                 }
@@ -1441,7 +1436,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
             case TR::SH_ASR:
                 op = is64bit ? OP::asrvx : OP::asrvw;
                 if (operandBits < 32) {
-                    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg,
+                    Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, srcReg,
                         operandBits - 1); // sxth or sxtb
                     shiftSrcReg = trgReg;
                 }
@@ -1449,7 +1444,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
             default:
                 TR_ASSERT(false, "Unsupported shift type.");
         }
-        generateTrg1Src2Instruction(cg, op, node, trgReg, shiftSrcReg, shiftAmountReg);
+        Inst_Trg1Src2(cg, op, node, trgReg, shiftSrcReg, shiftAmountReg);
     }
 
     node->setRegister(trgReg);
@@ -1473,7 +1468,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeG
             TR::Register *trgReg = (indexChild->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
             int32_t bitsToShift = secondChild->getInt();
             int32_t imm = ((64 - bitsToShift) << 6) | 31; // immr = 64 - bitsToShift, imms = 31
-            generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, trgReg, srcReg, imm);
+            Inst_Trg1Src1Imm(cg, OP::sbfmx, node, trgReg, srcReg, imm);
             node->setRegister(trgReg);
             cg->recursivelyDecReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
@@ -1523,7 +1518,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
         if (shift != 0) {
             shift = is64bit ? (64 - shift) : (32 - shift); // change ROL to ROR
             op = is64bit ? OP::extrx : OP::extrw; // ROR is an alias of EXTR
-            generateTrg1Src2ShiftedInstruction(cg, op, node, trgReg, trgReg, trgReg, TR::SH_LSL, shift);
+            Inst_Trg1Src2Shifted(cg, op, node, trgReg, trgReg, trgReg, TR::SH_LSL, shift);
         }
     } else {
         TR::Register *shiftAmountSrcReg;
@@ -1542,7 +1537,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
             if (is64bit) {
                 // 32->64 bit sign extension: SXTW is alias of SBFM
                 uint32_t imm = 0x1F; // immr=0, imms=31, N bit is pre-encoded in `sbfmx` opcode.
-                generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountSrcReg, imm);
+                Inst_Trg1Src1Imm(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountSrcReg, imm);
             }
             cg->decReferenceCount(shiftAmountNode);
         } else {
@@ -1551,15 +1546,15 @@ TR::Register *OMR::ARM64::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
             shiftAmountSrcReg = cg->evaluate(secondChild);
             shiftAmountReg = useTempReg ? tempReg : shiftAmountSrcReg;
 
-            generateNegInstruction(cg, node, shiftAmountReg, shiftAmountSrcReg); // change ROL to ROR
+            Inst_Neg(cg, node, shiftAmountReg, shiftAmountSrcReg); // change ROL to ROR
             if (is64bit) {
                 // 32->64 bit sign extension: SXTW is alias of SBFM
                 uint32_t imm = 0x1F; // immr=0, imms=31, N bit is pre-encoded in `sbfmx` opcode.
-                generateTrg1Src1ImmInstruction(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountReg, imm);
+                Inst_Trg1Src1Imm(cg, OP::sbfmx, node, shiftAmountReg, shiftAmountReg, imm);
             }
         }
         op = is64bit ? OP::rorvx : OP::rorvw;
-        generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, shiftAmountReg);
+        Inst_Trg1Src2(cg, op, node, trgReg, trgReg, shiftAmountReg);
 
         if (useTempReg) {
             cg->stopUsingRegister(tempReg);
@@ -1769,12 +1764,12 @@ static inline TR::Register *logicBinaryEvaluator(TR::Node *node, OP::Mnemonic re
             value = secondChild->getInt();
         }
         if (node->getOpCode().isXor() && (value == -1)) {
-            generateMvnInstruction(cg, node, trgReg, src1Reg, is64Bit);
+            Inst_Mvn(cg, node, trgReg, src1Reg, is64Bit);
         } else {
             bool N;
             uint32_t immEncoded;
             if (logicImmediateHelper(is64Bit ? value : (uint32_t)value, is64Bit, N, immEncoded)) {
-                generateLogicalImmInstruction(cg, regOpImm, node, trgReg, src1Reg, N, immEncoded);
+                Inst_LogicalImm(cg, regOpImm, node, trgReg, src1Reg, N, immEncoded);
             } else {
                 src2Reg = cg->allocateRegister();
                 if (is64Bit) {
@@ -1782,13 +1777,13 @@ static inline TR::Register *logicBinaryEvaluator(TR::Node *node, OP::Mnemonic re
                 } else {
                     loadConstant32(cg, node, value, src2Reg);
                 }
-                generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
+                Inst_Trg1Src2(cg, regOp, node, trgReg, src1Reg, src2Reg);
                 cg->stopUsingRegister(src2Reg);
             }
         }
     } else {
         src2Reg = cg->evaluate(secondChild);
-        generateTrg1Src2Instruction(cg, regOp, node, trgReg, src1Reg, src2Reg);
+        Inst_Trg1Src2(cg, regOp, node, trgReg, src1Reg, src2Reg);
     }
 
     node->setRegister(trgReg);
@@ -1838,7 +1833,7 @@ static TR::Register *generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGene
                  * The result is always 0 in this case.
                  */
                 TR::Register *reg = cg->allocateRegister();
-                generateTrg1ImmInstruction(cg, OP::movzx, andNode, reg, 0);
+                Inst_Trg1Imm(cg, OP::movzx, andNode, reg, 0);
                 andNode->setRegister(reg);
                 cg->recursivelyDecReferenceCount(shiftNode);
                 cg->decReferenceCount(maskNode);
@@ -1861,7 +1856,7 @@ static TR::Register *generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGene
                 } else {
                     reg = cg->allocateRegister();
                 }
-                generateUBFIZInstruction(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
+                Inst_UBFIZ(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
                 andNode->setRegister(reg);
                 cg->recursivelyDecReferenceCount(shiftNode);
                 cg->decReferenceCount(maskNode);
@@ -1900,13 +1895,13 @@ static TR::Register *generateUBFMForShiftAndMask(TR::Node *andNode, TR::CodeGene
                 }
                 if (isLogicalShiftRight) {
                     if (operandBits < 32) {
-                        generateTrg1Src1ImmInstruction(cg, OP::ubfmw, andNode, reg, sreg,
+                        Inst_Trg1Src1Imm(cg, OP::ubfmw, andNode, reg, sreg,
                             operandBits - 1); // uxth or uxtb
                         shiftSrcReg = reg;
                     }
-                    generateLogicalShiftRightImmInstruction(cg, andNode, reg, shiftSrcReg, shiftValue, is64bit);
+                    Inst_LogicalShiftRightImm(cg, andNode, reg, shiftSrcReg, shiftValue, is64bit);
                 } else {
-                    generateUBFXInstruction(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
+                    Inst_UBFX(cg, andNode, reg, sreg, static_cast<uint32_t>(shiftValue), width, is64bit);
                 }
                 andNode->setRegister(reg);
                 cg->recursivelyDecReferenceCount(shiftNode);

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -44,7 +44,7 @@ TR::Register *genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rn
 
     auto *deps = RegDeps(1, 0, cg);
     deps->addPreCondition(returnRegister, rnum);
-    generateAdminInstruction(cg, OP::retn, node, deps);
+    Inst_Admin(cg, OP::retn, node, deps);
 
     cg->comp()->setReturnInfo(i);
     cg->decReferenceCount(firstChild);
@@ -70,7 +70,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::areturnEvaluator(TR::Node *node, TR::Co
 // void return
 TR::Register *OMR::ARM64::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateAdminInstruction(cg, OP::retn, node);
+    Inst_Admin(cg, OP::retn, node);
     cg->comp()->setReturnInfo(TR_VoidReturn);
     return NULL;
 }
@@ -81,10 +81,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeG
     if (node->getNumChildren() > 0) {
         TR::Node *child = node->getFirstChild();
         cg->evaluate(child);
-        generateLabelInstruction(cg, OP::b, node, gotoLabel, RegDeps(cg, child, 0));
+        Inst_Label(cg, OP::b, node, gotoLabel, RegDeps(cg, child, 0));
         cg->decReferenceCount(child);
     } else {
-        generateLabelInstruction(cg, OP::b, node, gotoLabel);
+        Inst_Label(cg, OP::b, node, gotoLabel);
     }
     return NULL;
 }
@@ -209,9 +209,9 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
                 if (!deps->getPreConditions()->containsVirtualRegister(src1Reg, numPreConditions)) {
                     TR::addDependency(deps, src1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
                 }
-                result = generateCompareBranchInstruction(cg, op, node, src1Reg, dstLabel, deps);
+                result = Inst_CompareBranch(cg, op, node, src1Reg, dstLabel, deps);
             } else {
-                result = generateCompareBranchInstruction(cg, op, node, src1Reg, dstLabel);
+                result = Inst_CompareBranch(cg, op, node, src1Reg, dstLabel);
             }
 
             cg->decReferenceCount(firstChild);
@@ -229,14 +229,14 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
         int64_t value = is64bit ? secondChild->getLongInt() : secondChild->getInt();
         if (constantIsUnsignedImm12(value) || constantIsUnsignedImm12(-value) || constantIsUnsignedImm12Shifted(value)
             || constantIsUnsignedImm12Shifted(-value)) {
-            generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
+            Inst_CompareImm(cg, node, src1Reg, value, is64bit);
             useRegCompare = false;
         }
     }
 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateCompareInstruction(cg, node, src1Reg, src2Reg, is64bit);
+        Inst_Compare(cg, node, src1Reg, src2Reg, is64bit);
     }
 
     dstLabel = node->getBranchDestination()->getNode()->getLabel();
@@ -248,9 +248,9 @@ static TR::Instruction *ificmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
         cg->evaluate(thirdChild);
 
         deps = RegDeps(cg, thirdChild, 0);
-        result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
+        result = Inst_ConditionalBranch(cg, node, dstLabel, cc, deps);
     } else {
-        result = generateConditionalBranchInstruction(cg, node, dstLabel, cc);
+        result = Inst_ConditionalBranch(cg, node, dstLabel, cc);
     }
 
     cg->decReferenceCount(firstChild);
@@ -402,17 +402,17 @@ static TR::Register *icmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
         int64_t value = is64bit ? secondChild->getLongInt() : secondChild->getInt();
         if (constantIsUnsignedImm12(value) || constantIsUnsignedImm12(-value) || constantIsUnsignedImm12Shifted(value)
             || constantIsUnsignedImm12Shifted(-value)) {
-            generateCompareImmInstruction(cg, node, src1Reg, value, is64bit);
+            Inst_CompareImm(cg, node, src1Reg, value, is64bit);
             useRegCompare = false;
         }
     }
 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
-        generateCompareInstruction(cg, node, src1Reg, src2Reg, is64bit);
+        Inst_Compare(cg, node, src1Reg, src2Reg, is64bit);
     }
 
-    generateCSetInstruction(cg, node, trgReg, cc);
+    Inst_CSet(cg, node, trgReg, cc);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -545,10 +545,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
     TR::Register *trgReg = cg->allocateRegister();
     TR::Register *tmpReg = cg->allocateRegister();
 
-    generateCompareInstruction(cg, node, src1Reg, src2Reg, true);
-    generateCSetInstruction(cg, node, trgReg, TR::CC_GE);
-    generateCSetInstruction(cg, node, tmpReg, TR::CC_LE);
-    generateTrg1Src2Instruction(cg, OP::subw, node, trgReg, trgReg, tmpReg);
+    Inst_Compare(cg, node, src1Reg, src2Reg, true);
+    Inst_CSet(cg, node, trgReg, TR::CC_GE);
+    Inst_CSet(cg, node, tmpReg, TR::CC_LE);
+    Inst_Trg1Src2(cg, OP::subw, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -571,9 +571,9 @@ static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNod
 
         if (!constantIsUnsignedImm12(pivotValue)) {
             loadConstant32(cg, lookupNode, pivotValue, tmpRegister);
-            generateCompareInstruction(cg, lookupNode, selectorReg, tmpRegister);
+            Inst_Compare(cg, lookupNode, selectorReg, tmpRegister);
         } else {
-            generateCompareImmInstruction(cg, lookupNode, selectorReg, pivotValue);
+            Inst_CompareImm(cg, lookupNode, selectorReg, pivotValue);
         }
 
         int32_t lowVal = lookupNode->getChild(lowChild)->getCaseConstant();
@@ -583,19 +583,19 @@ static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNod
         TR::ARM64ConditionCode branchCond = (highVal < lowVal) ? TR::CC_HI : TR::CC_GT;
 
         TR::LabelSymbol *upperLabel = generateLabelSymbol(cg);
-        generateConditionalBranchInstruction(cg, lookupNode, upperLabel, branchCond);
+        Inst_ConditionalBranch(cg, lookupNode, upperLabel, branchCond);
 
         if (lowChild == pivot) {
-            generateConditionalBranchInstruction(cg, lookupNode,
+            Inst_ConditionalBranch(cg, lookupNode,
                 lookupNode->getChild(lowChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
 
             // default case
-            generateLabelInstruction(cg, OP::b, lookupNode,
-                lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
+            Inst_Label(cg, OP::b, lookupNode, lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(),
+                conditions);
         } else {
             binarySearchCaseSpace(selectorReg, lookupNode, lowChild, pivot, tmpRegister, conditions, cg);
         }
-        generateLabelInstruction(cg, OP::label, lookupNode, upperLabel);
+        Inst_Label(cg, OP::label, lookupNode, upperLabel);
     }
 
     // upper half
@@ -603,16 +603,16 @@ static void binarySearchCaseSpace(TR::Register *selectorReg, TR::Node *lookupNod
         int32_t highValue = lookupNode->getChild(highChild)->getCaseConstant();
         if (!constantIsUnsignedImm12(highValue)) {
             loadConstant32(cg, lookupNode, highValue, tmpRegister);
-            generateCompareInstruction(cg, lookupNode, selectorReg, tmpRegister);
+            Inst_Compare(cg, lookupNode, selectorReg, tmpRegister);
         } else {
-            generateCompareImmInstruction(cg, lookupNode, selectorReg, highValue);
+            Inst_CompareImm(cg, lookupNode, selectorReg, highValue);
         }
-        generateConditionalBranchInstruction(cg, lookupNode,
+        Inst_ConditionalBranch(cg, lookupNode,
             lookupNode->getChild(highChild)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, conditions);
 
         // default case
-        generateLabelInstruction(cg, OP::b, lookupNode,
-            lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(), conditions);
+        Inst_Label(cg, OP::b, lookupNode, lookupNode->getChild(1)->getBranchDestination()->getNode()->getLabel(),
+            conditions);
     } else {
         binarySearchCaseSpace(selectorReg, lookupNode, pivot + 1, highChild, tmpRegister, conditions, cg);
     }
@@ -649,9 +649,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
 
             if (!constantIsUnsignedImm12(caseValue)) {
                 loadConstant32(cg, node, caseValue, tmpRegister);
-                generateCompareInstruction(cg, node, selectorReg, tmpRegister);
+                Inst_Compare(cg, node, selectorReg, tmpRegister);
             } else {
-                generateCompareImmInstruction(cg, node, selectorReg, caseValue);
+                Inst_CompareImm(cg, node, selectorReg, caseValue);
             }
 
             TR::RegisterDependencyConditions *cond = conditions;
@@ -660,8 +660,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
                 cg->evaluate(child->getFirstChild());
                 cond = cond->clone(cg, RegDeps(cg, child->getFirstChild(), 0));
             }
-            generateConditionalBranchInstruction(cg, node, child->getBranchDestination()->getNode()->getLabel(),
-                TR::CC_EQ, cond);
+            Inst_ConditionalBranch(cg, node, child->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ, cond);
         }
 
         // Branch to default
@@ -670,8 +669,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lookupEvaluator(TR::Node *node, TR::Cod
             cg->evaluate(defaultChild->getFirstChild());
             conditions = conditions->clone(cg, RegDeps(cg, defaultChild->getFirstChild(), 0));
         }
-        generateLabelInstruction(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
-            conditions);
+        Inst_Label(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(), conditions);
     }
 
     if (tmpRegister) {
@@ -708,33 +706,30 @@ TR::Register *OMR::ARM64::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
 
     if (5 > numBranchTableEntries) {
         for (i = 0; i < numBranchTableEntries; i++) {
-            generateCompareImmInstruction(cg, node, selectorReg, i);
-            generateConditionalBranchInstruction(cg, node,
-                node->getChild(2 + i)->getBranchDestination()->getNode()->getLabel(), TR::CC_EQ);
+            Inst_CompareImm(cg, node, selectorReg, i);
+            Inst_ConditionalBranch(cg, node, node->getChild(2 + i)->getBranchDestination()->getNode()->getLabel(),
+                TR::CC_EQ);
         }
 
-        generateLabelInstruction(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
-            conditions);
+        Inst_Label(cg, OP::b, node, defaultChild->getBranchDestination()->getNode()->getLabel(), conditions);
     } else {
         if (!constantIsUnsignedImm12(numBranchTableEntries)) {
             loadConstant32(cg, node, numBranchTableEntries, tmpRegister);
-            generateCompareInstruction(cg, node, selectorReg, tmpRegister);
+            Inst_Compare(cg, node, selectorReg, tmpRegister);
         } else {
-            generateCompareImmInstruction(cg, node, selectorReg, numBranchTableEntries);
+            Inst_CompareImm(cg, node, selectorReg, numBranchTableEntries);
         }
 
-        generateConditionalBranchInstruction(cg, node, defaultChild->getBranchDestination()->getNode()->getLabel(),
-            TR::CC_CS);
-        generateTrg1ImmInstruction(cg, OP::adr, node, tmpRegister,
+        Inst_ConditionalBranch(cg, node, defaultChild->getBranchDestination()->getNode()->getLabel(), TR::CC_CS);
+        Inst_Trg1Imm(cg, OP::adr, node, tmpRegister,
             12); // distance between this instruction to the jump table
-        generateTrg1Src2ShiftedInstruction(cg, OP::addx, node, tmpRegister, tmpRegister, selectorReg, TR::SH_LSL, 2);
-        generateRegBranchInstruction(cg, OP::br, node, tmpRegister);
+        Inst_Trg1Src2Shifted(cg, OP::addx, node, tmpRegister, tmpRegister, selectorReg, TR::SH_LSL, 2);
+        Inst_RegBranch(cg, OP::br, node, tmpRegister);
 
         for (i = 2; i < node->getNumChildren() - 1; i++) {
-            generateLabelInstruction(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel());
+            Inst_Label(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel());
         }
-        generateLabelInstruction(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel(),
-            conditions);
+        Inst_Label(cg, OP::b, node, node->getChild(i)->getBranchDestination()->getNode()->getLabel(), conditions);
     }
 
     if (NULL != tmpRegister)
@@ -763,11 +758,11 @@ static TR::Register *commonMinMaxEvaluator(TR::Node *node, bool is64bit, TR::ARM
     TR::Register *src2Reg = cg->evaluate(secondChild);
 
     // ToDo:
-    // Optimize the code by using generateCompareImmInstruction() when possible
-    generateCompareInstruction(cg, node, src1Reg, src2Reg, is64bit);
+    // Optimize the code by using Inst_CompareImm() when possible
+    Inst_Compare(cg, node, src1Reg, src2Reg, is64bit);
 
     OP::Mnemonic op = is64bit ? OP::cselx : OP::cselw;
-    generateCondTrg1Src2Instruction(cg, op, node, trgReg, src1Reg, src2Reg, cc);
+    Inst_CondTrg1Src2(cg, op, node, trgReg, src1Reg, src2Reg, cc);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -908,15 +903,15 @@ TR::Register *OMR::ARM64::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::Co
         TR::Register *cmp2Reg = cg->evaluate(cmp2Node);
         bool is64bit = (TR::DataType::getSize(cmp1Node->getDataType()) == 8);
 
-        generateCompareInstruction(cg, node, cmp1Reg, cmp2Reg, is64bit);
-        generateCondTrg1Src2Instruction(cg, OP::cselx, node, resultReg, trueReg, falseReg, cc);
+        Inst_Compare(cg, node, cmp1Reg, cmp2Reg, is64bit);
+        Inst_CondTrg1Src2(cg, OP::cselx, node, resultReg, trueReg, falseReg, cc);
 
         cg->recursivelyDecReferenceCount(condNode);
     } else {
         TR::Register *condReg = cg->evaluate(condNode);
 
-        generateCompareImmInstruction(cg, node, condReg, 0, true); // 64-bit compare
-        generateCondTrg1Src2Instruction(cg, OP::cselx, node, resultReg, trueReg, falseReg, TR::CC_NE);
+        Inst_CompareImm(cg, node, condReg, 0, true); // 64-bit compare
+        Inst_CondTrg1Src2(cg, OP::cselx, node, resultReg, trueReg, falseReg, TR::CC_NE);
 
         cg->decReferenceCount(condNode);
     }
@@ -1007,9 +1002,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::igotoEvaluator(TR::Node *node, TR::Code
         cg->decReferenceCount(glregdep);
     }
     if (deps)
-        generateRegBranchInstruction(cg, OP::br, node, addrReg, deps);
+        Inst_RegBranch(cg, OP::br, node, addrReg, deps);
     else
-        generateRegBranchInstruction(cg, OP::br, node, addrReg);
+        Inst_RegBranch(cg, OP::br, node, addrReg);
     cg->decReferenceCount(labelAddr);
     node->setRegister(NULL);
     return NULL;

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -34,7 +34,7 @@ static void fpBitsMovHelper(TR::Node *node, OP::Mnemonic op, TR::Register *trgRe
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
 
-    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, srcReg);
 
     cg->decReferenceCount(child);
 }
@@ -74,18 +74,18 @@ static TR::Register *fpBits2integerHelper(TR::Node *node, bool is64bit, TR::Code
         selOp = OP::cselx;
     }
 
-    generateTrg1Src1Instruction(cg, movOp, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, movOp, node, trgReg, srcReg);
 
     if (node->normalizeNanValues()) {
         TR::Register *tmpReg = cg->allocateRegister();
 
-        generateSrc2Instruction(cg, cmpOp, node, srcReg, srcReg);
+        Inst_Src2(cg, cmpOp, node, srcReg, srcReg);
         if (is64bit) {
             loadConstant64(cg, node, DOUBLE_NAN, tmpReg);
         } else {
             loadConstant32(cg, node, FLOAT_NAN, tmpReg);
         }
-        generateCondTrg1Src2Instruction(cg, selOp, node, trgReg, tmpReg, trgReg, TR::CC_VS);
+        Inst_CondTrg1Src2(cg, selOp, node, trgReg, tmpReg, trgReg, TR::CC_VS);
 
         cg->stopUsingRegister(tmpReg);
     }
@@ -198,7 +198,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::Cod
     uint16_t imm8 = getImm8forFloat(node->getFloat());
 
     if (imm8 != 256) {
-        generateTrg1ImmInstruction(cg, OP::fmovimms, node, trgReg, (uint32_t)imm8);
+        Inst_Trg1Imm(cg, OP::fmovimms, node, trgReg, (uint32_t)imm8);
     } else {
         union {
             float f;
@@ -208,11 +208,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::Cod
         fvalue.f = node->getFloat();
 
         if (fvalue.f == +0.0f && signbit(fvalue.f) == 0) {
-            generateTrg1ImmInstruction(cg, OP::vmovi2s, node, trgReg, 0);
+            Inst_Trg1Imm(cg, OP::vmovi2s, node, trgReg, 0);
         } else {
             TR::Register *tmpReg = cg->allocateRegister();
             loadConstant32(cg, node, fvalue.i, tmpReg);
-            generateTrg1Src1Instruction(cg, OP::fmov_wtos, node, trgReg, tmpReg);
+            Inst_Trg1Src1(cg, OP::fmov_wtos, node, trgReg, tmpReg);
             cg->stopUsingRegister(tmpReg);
         }
     }
@@ -227,7 +227,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
     uint16_t imm8 = getImm8forDouble(node->getDouble());
 
     if (imm8 != 256) {
-        generateTrg1ImmInstruction(cg, OP::fmovimmd, node, trgReg, (uint32_t)imm8);
+        Inst_Trg1Imm(cg, OP::fmovimmd, node, trgReg, (uint32_t)imm8);
     } else {
         union {
             double d;
@@ -237,11 +237,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
         dvalue.d = node->getDouble();
 
         if (dvalue.d == +0.0 && signbit(dvalue.d) == 0) {
-            generateTrg1ImmInstruction(cg, OP::movid, node, trgReg, 0);
+            Inst_Trg1Imm(cg, OP::movid, node, trgReg, 0);
         } else {
             TR::Register *tmpReg = cg->allocateRegister();
             loadConstant64(cg, node, dvalue.l, tmpReg);
-            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, trgReg, tmpReg);
+            Inst_Trg1Src1(cg, OP::fmov_xtod, node, trgReg, tmpReg);
             cg->stopUsingRegister(tmpReg);
         }
     }
@@ -293,7 +293,7 @@ static TR::Register *commonFpEvaluator(TR::Node *node, OP::Mnemonic op, bool isD
     TR::Register *trgReg;
 
     trgReg = isDouble ? cg->allocateRegister(TR_FPR) : cg->allocateSinglePrecisionRegister();
-    generateTrg1Src2Instruction(cg, op, node, trgReg, src1Reg, src2Reg);
+    Inst_Trg1Src2(cg, op, node, trgReg, src1Reg, src2Reg);
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
     node->setRegister(trgReg);
@@ -371,7 +371,7 @@ static TR::Register *commonFpUnaryEvaluator(TR::Node *node, OP::Mnemonic op, boo
     } else {
         trgReg = srcReg;
     }
-    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, srcReg);
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
     return trgReg;
@@ -430,7 +430,7 @@ static TR::Register *intFpTypeConversionHelper(TR::Node *node, OP::Mnemonic op, 
         trgReg = cg->allocateRegister();
     }
 
-    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, srcReg);
 
     cg->decReferenceCount(child);
     node->setRegister(trgReg);
@@ -516,7 +516,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
         double value = isDouble ? secondChild->getDouble() : secondChild->getFloat();
         if (value == 0.0) {
             op = isDouble ? OP::fcmpd_zero : OP::fcmps_zero;
-            generateSrc1Instruction(cg, op, node, src1Reg);
+            Inst_Src1(cg, op, node, src1Reg);
             useRegCompare = false;
         }
     }
@@ -524,7 +524,7 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
         op = isDouble ? OP::fcmpd : OP::fcmps;
-        generateSrc2Instruction(cg, op, node, src1Reg, src2Reg);
+        Inst_Src2(cg, op, node, src1Reg, src2Reg);
     }
 
     TR::LabelSymbol *dstLabel = node->getBranchDestination()->getNode()->getLabel();
@@ -538,32 +538,32 @@ static TR::Instruction *iffcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, 
 
         auto *deps = RegDeps(cg, thirdChild, 0);
         if (!needsExplicitUnorderedCheck) {
-            result = generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
+            result = Inst_ConditionalBranch(cg, node, dstLabel, cc, deps);
         } else {
             if (cc == TR::CC_NE) {
                 /* iffcmpne/ifdcmpne: false if CC_VS is set */
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
-                generateConditionalBranchInstruction(cg, node, dstLabel, cc, deps);
-                result = generateLabelInstruction(cg, OP::label, node, doneLabel);
+                Inst_ConditionalBranch(cg, node, doneLabel, TR::CC_VS);
+                Inst_ConditionalBranch(cg, node, dstLabel, cc, deps);
+                result = Inst_Label(cg, OP::label, node, doneLabel);
             } else {
-                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
-                result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS, deps);
+                Inst_ConditionalBranch(cg, node, dstLabel, cc);
+                result = Inst_ConditionalBranch(cg, node, dstLabel, TR::CC_VS, deps);
             }
         }
     } else {
         if (!needsExplicitUnorderedCheck) {
-            result = generateConditionalBranchInstruction(cg, node, dstLabel, cc);
+            result = Inst_ConditionalBranch(cg, node, dstLabel, cc);
         } else {
             if (cc == TR::CC_NE) {
                 /* iffcmpne/ifdcmpne: false if CC_VS is set */
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_VS);
-                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
-                result = generateLabelInstruction(cg, OP::label, node, doneLabel);
+                Inst_ConditionalBranch(cg, node, doneLabel, TR::CC_VS);
+                Inst_ConditionalBranch(cg, node, dstLabel, cc);
+                result = Inst_Label(cg, OP::label, node, doneLabel);
             } else {
-                generateConditionalBranchInstruction(cg, node, dstLabel, cc);
-                result = generateConditionalBranchInstruction(cg, node, dstLabel, TR::CC_VS);
+                Inst_ConditionalBranch(cg, node, dstLabel, cc);
+                result = Inst_ConditionalBranch(cg, node, dstLabel, TR::CC_VS);
             }
         }
     }
@@ -662,7 +662,7 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
         double value = isDouble ? secondChild->getDouble() : secondChild->getFloat();
         if (value == 0.0) {
             op = isDouble ? OP::fcmpd_zero : OP::fcmps_zero;
-            generateSrc1Instruction(cg, op, node, src1Reg);
+            Inst_Src1(cg, op, node, src1Reg);
             useRegCompare = false;
         }
     }
@@ -670,16 +670,16 @@ static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool 
     if (useRegCompare) {
         TR::Register *src2Reg = cg->evaluate(secondChild);
         op = isDouble ? OP::fcmpd : OP::fcmps;
-        generateSrc2Instruction(cg, op, node, src1Reg, src2Reg);
+        Inst_Src2(cg, op, node, src1Reg, src2Reg);
     }
 
-    generateCSetInstruction(cg, node, trgReg, cc);
+    Inst_CSet(cg, node, trgReg, cc);
     if (needsExplicitUnorderedCheck) {
         TR::Register *tmpReg = cg->allocateRegister();
         TR::ARM64ConditionCode ccNan = (cc == TR::CC_NE) ? TR::CC_VC : TR::CC_VS;
         op = (cc == TR::CC_NE) ? OP::andx : OP::orrx;
-        generateCSetInstruction(cg, node, tmpReg, ccNan);
-        generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, tmpReg);
+        Inst_CSet(cg, node, tmpReg, ccNan);
+        Inst_Trg1Src2(cg, op, node, trgReg, trgReg, tmpReg);
         cg->stopUsingRegister(tmpReg);
     }
 
@@ -765,12 +765,12 @@ static TR::Register *floatThreeWayCompareHelper(TR::Node *node, bool isDouble, b
     uint32_t movVal = isCmpl ? 1 : 0;
     TR::ARM64ConditionCode cc = isCmpl ? TR::CC_GT : TR::CC_MI;
 
-    generateSrc2Instruction(cg, cmpOp, node, src1Reg, src2Reg); // compare
-    generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0);
-    generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
-    generateTrg1ImmInstruction(cg, movOp, node, trgReg, movVal); // 1 or -1
-    generateCondTrg1Src2Instruction(cg, OP::csnegx, node, trgReg, trgReg, trgReg, cc);
-    generateLabelInstruction(cg, OP::label, node, doneLabel);
+    Inst_Src2(cg, cmpOp, node, src1Reg, src2Reg); // compare
+    Inst_Trg1Imm(cg, OP::movzx, node, trgReg, 0);
+    Inst_ConditionalBranch(cg, node, doneLabel, TR::CC_EQ);
+    Inst_Trg1Imm(cg, movOp, node, trgReg, movVal); // 1 or -1
+    Inst_CondTrg1Src2(cg, OP::csnegx, node, trgReg, trgReg, trgReg, cc);
+    Inst_Label(cg, OP::label, node, doneLabel);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -838,7 +838,7 @@ static TR::Register *fpMinMaxHelper(TR::Node *node, bool isMax, bool isDouble, T
         op = isDouble ? OP::fmind : OP::fmins;
     }
 
-    generateTrg1Src2Instruction(cg, op, node, trgReg, src1Reg, src2Reg);
+    Inst_Trg1Src2(cg, op, node, trgReg, src1Reg, src2Reg);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(firstChild);
@@ -1032,9 +1032,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::fselectEvaluator(TR::Node *node, TR::Co
         resultReg = isDouble ? cg->allocateRegister(TR_FPR) : cg->allocateSinglePrecisionRegister();
     }
 
-    generateCompareImmInstruction(cg, node, condReg, 0, true); // 64-bit compare
+    Inst_CompareImm(cg, node, condReg, 0, true); // 64-bit compare
     OP::Mnemonic fcselOp = isDouble ? OP::fcseld : OP::fcsels;
-    generateCondTrg1Src2Instruction(cg, fcselOp, node, resultReg, trueReg, falseReg, TR::CC_NE);
+    Inst_CondTrg1Src2(cg, fcselOp, node, resultReg, trueReg, falseReg, TR::CC_NE);
 
     node->setRegister(resultReg);
     cg->decReferenceCount(condNode);

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -39,14 +39,14 @@ class RegisterDependencyConditions;
 class SymbolReference;
 } // namespace TR
 
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Instruction *preced)
+TR::Instruction *Inst(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::Instruction(op, node, preced, cg);
     return new (cg->trHeapMemory()) TR::Instruction(op, node, cg);
 }
 
-TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+TR::ARM64ImmInstruction *Inst_Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
     TR::Instruction *preced)
 {
     if (preced)
@@ -54,16 +54,16 @@ TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemo
     return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, cg);
 }
 
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced)
+TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64RelocatableImmInstruction(op, node, imm, relocationKind, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64RelocatableImmInstruction(op, node, imm, relocationKind, cg);
 }
 
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced)
+TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory())
@@ -71,7 +71,7 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mn
     return new (cg->trHeapMemory()) TR::ARM64RelocatableImmInstruction(op, node, imm, relocationKind, sr, cg);
 }
 
-TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+TR::Instruction *Inst_ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
     TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced)
 {
     if (preced)
@@ -79,7 +79,7 @@ TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic o
     return new (cg->trHeapMemory()) TR::ARM64ImmSymInstruction(op, node, imm, cond, sr, s, cg);
 }
 
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::Instruction *preced)
 {
     if (preced)
@@ -87,7 +87,7 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
     return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cg);
 }
 
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
@@ -95,7 +95,7 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
     return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cond, cg);
 }
 
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::Instruction *preced)
 {
     if (preced)
@@ -103,7 +103,7 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
     return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, cg);
 }
 
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
@@ -112,33 +112,32 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
     return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(OP::b_cond, node, sym, cc, cond, cg);
 }
 
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced)
+TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    TR::LabelSymbol *sym, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cg);
 }
 
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cond, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cond, cg);
 }
 
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced)
+TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64TestBitBranchInstruction(op, node, sreg, bitpos, sym, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64TestBitBranchInstruction(op, node, sreg, bitpos, sym, cg);
 }
 
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced)
+TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory())
@@ -146,23 +145,23 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mne
     return new (cg->trHeapMemory()) TR::ARM64TestBitBranchInstruction(op, node, sreg, bitpos, sym, cond, cg);
 }
 
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Instruction *preced)
+TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cg);
 }
 
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
+TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cond, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cond, cg);
 }
 
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
+TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
     TR::Instruction *preced)
 {
     if (preced)
@@ -170,7 +169,7 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
     return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, node, fenceNode, cg);
 }
 
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::RegisterDependencyConditions *cond, TR::Node *fenceNode, TR::Instruction *preced)
 {
     if (preced)
@@ -178,24 +177,16 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
     return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, cond, node, fenceNode, cg);
 }
 
-TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
     TR::Instruction *preced)
-{
-    if (preced)
-        return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64Trg1Instruction(op, node, treg, cg);
-}
-
-TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
-    uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ImmInstruction(op, node, treg, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmInstruction(op, node, treg, imm, cg);
 }
 
-TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1ImmShifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory())
@@ -203,15 +194,15 @@ TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mn
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmShiftedInstruction(op, node, treg, imm, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, TR::Symbol *sym, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1ImmSymInstruction(op, node, treg, imm, sym, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1ImmSymInstruction(op, node, treg, imm, sym, cg);
 }
 
-TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Instruction *preced)
 {
     if (preced)
@@ -219,8 +210,8 @@ TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1Instruction(op, node, treg, s1reg, cg);
 }
 
-TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1Src1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, uint32_t imm, TR::Instruction *preced)
 {
     bool isShifted = false;
 
@@ -241,7 +232,7 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemo
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, s1reg, isShifted, imm, cg);
 }
 
-TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
@@ -249,34 +240,24 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *preced)
+TR::Instruction *Inst_CondTrg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cg);
 }
 
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
-{
-    if (preced)
-        return new (cg->trHeapMemory())
-            TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cond, preced, cg);
-    return new (cg->trHeapMemory()) TR::ARM64CondTrg1Src2Instruction(op, node, treg, s1reg, s2reg, cc, cond, cg);
-}
-
-TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1Src2Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ImmInstruction(op, node, treg, s1reg, s2reg, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ImmInstruction(op, node, treg, s1reg, s2reg, imm, cg);
 }
 
-TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
+TR::Instruction *Inst_Trg1Src2Shifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
     TR::Instruction *preced)
 {
     if (preced)
@@ -286,8 +267,8 @@ TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::M
         TR::ARM64Trg1Src2ShiftedInstruction(op, node, treg, s1reg, s2reg, shiftType, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
+TR::Instruction *Inst_Trg1Src2Extended(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
     TR::Instruction *preced)
 {
     if (preced)
@@ -297,8 +278,8 @@ TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::
         TR::ARM64Trg1Src2ExtendedInstruction(op, node, treg, s1reg, s2reg, extendType, shiftAmount, cg);
 }
 
-TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1Src2IndexedElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced)
 {
     if ((op >= OP::fmulelem_4s) && (op <= OP::vfmulelem_2d)) {
         if ((op == OP::fmulelem_4s) || (op == OP::vfmulelem_4s)) {
@@ -315,7 +296,7 @@ TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2IndexedElementInstruction(op, node, treg, s1reg, s2reg, index, cg);
 }
 
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src3(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced)
 {
     if (preced)
@@ -323,7 +304,7 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, s3reg, cg);
 }
 
-TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Instruction *preced)
 {
     if (preced)
@@ -331,7 +312,7 @@ TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
     return new (cg->trHeapMemory()) TR::ARM64Trg1MemInstruction(op, node, treg, mr, cg);
 }
 
-TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
+TR::Instruction *Inst_Trg2Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
     TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced)
 {
     if (preced)
@@ -339,39 +320,39 @@ TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
     return new (cg->trHeapMemory()) TR::ARM64Trg2MemInstruction(op, node, treg1, treg2, mr, cg);
 }
 
-TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced)
+TR::Instruction *Inst_MemImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64MemImmInstruction(op, node, mr, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64MemImmInstruction(op, node, mr, imm, cg);
 }
 
-TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
+TR::Instruction *Inst_MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    TR::Register *sreg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64MemSrc1Instruction(op, node, mr, sreg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64MemSrc1Instruction(op, node, mr, sreg, cg);
 }
 
-TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+TR::Instruction *Inst_MemSrc2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64MemSrc2Instruction(op, node, mr, s1reg, s2reg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64MemSrc2Instruction(op, node, mr, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
+TR::Instruction *Inst_Trg1MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1MemSrc1Instruction(op, node, treg, mr, sreg, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1MemSrc1Instruction(op, node, treg, mr, sreg, cg);
 }
 
-TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+TR::Instruction *Inst_Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Instruction *preced)
 {
     if (preced)
@@ -379,7 +360,7 @@ TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op,
     return new (cg->trHeapMemory()) TR::ARM64Src1Instruction(op, node, s1reg, cg);
 }
 
-TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+TR::Instruction *Inst_Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced)
 {
     if (preced)
@@ -387,7 +368,7 @@ TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op,
     return new (cg->trHeapMemory()) TR::ARM64Src2Instruction(op, node, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_ArithmeticShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of SBFM instruction */
@@ -404,7 +385,7 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *c
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, sreg, imm, cg);
 }
 
-TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_LogicalShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of UBFM instruction */
@@ -421,8 +402,8 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, 
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, sreg, imm, cg);
 }
 
-TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_LogicalShiftLeftImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    uint32_t shiftAmount, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of UBFM instruction */
 
@@ -438,16 +419,16 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, sreg, imm, cg);
 }
 
-TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced)
+TR::Instruction *Inst_LogicalImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, s1reg, N, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, treg, s1reg, N, imm, cg);
 }
 
-TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
-    bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_CompareImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm, bool is64bit,
+    TR::Instruction *preced)
 {
     OP::Mnemonic op;
     bool isShifted = false;
@@ -477,8 +458,8 @@ TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *
     return new (cg->trHeapMemory()) TR::ARM64ZeroSrc1ImmInstruction(op, node, sreg, isShifted, imm, cg);
 }
 
-TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
-    bool N, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_TestImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm, bool N,
+    bool is64bit, TR::Instruction *preced)
 {
     /* Alias of ANDS instruction */
 
@@ -489,8 +470,8 @@ TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *nod
     return new (cg->trHeapMemory()) TR::ARM64ZeroSrc1ImmInstruction(op, node, sreg, N, imm, cg);
 }
 
-TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_Compare(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    bool is64bit, TR::Instruction *preced)
 {
     /* Alias of SUBS instruction */
 
@@ -501,8 +482,8 @@ TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *nod
     return new (cg->trHeapMemory()) TR::ARM64ZeroSrc2Instruction(op, node, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_Test(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    bool is64bit, TR::Instruction *preced)
 {
     /* Alias of ANDS instruction */
 
@@ -513,9 +494,8 @@ TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, 
     return new (cg->trHeapMemory()) TR::ARM64ZeroSrc2Instruction(op, node, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
-    uint32_t imm, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit, bool isNegative,
-    TR::Instruction *preced)
+TR::Instruction *Inst_ConditionalCompareImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, uint32_t imm,
+    uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit, bool isNegative, TR::Instruction *preced)
 {
     OP::Mnemonic op = is64bit ? (isNegative ? OP::ccmnimmx : OP::ccmpimmx) : (isNegative ? OP::ccmnimmw : OP::ccmpimmw);
 
@@ -527,7 +507,7 @@ TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg,
     return new (cg->trHeapMemory()) TR::ARM64Src1ImmCondInstruction(op, node, sreg, imm, cc, conditionFlags, cg);
 }
 
-TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg1,
+TR::Instruction *Inst_ConditionalCompare(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg1,
     TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit, bool isNegative,
     TR::Instruction *preced)
 {
@@ -539,8 +519,8 @@ TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR
     return new (cg->trHeapMemory()) TR::ARM64Src2CondInstruction(op, node, sreg1, sreg2, cc, conditionFlags, cg);
 }
 
-TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_Mov(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, bool is64bit,
+    TR::Instruction *preced)
 {
     /* Alias of ORR instruction */
 
@@ -551,8 +531,8 @@ TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, cg);
 }
 
-TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_Mvn(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, bool is64bit,
+    TR::Instruction *preced)
 {
     /* Alias of ORN instruction */
 
@@ -563,8 +543,8 @@ TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, cg);
 }
 
-TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_Neg(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, bool is64bit,
+    TR::Instruction *preced)
 {
     /* Alias of SUB instruction */
 
@@ -575,8 +555,8 @@ TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroSrc1Instruction(op, node, treg, sreg, cg);
 }
 
-TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N,
-    uint32_t imm, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_MovBitMask(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
+    bool is64bit, TR::Instruction *preced)
 {
     /* Alias of ORR instruction */
     OP::Mnemonic op = is64bit ? OP::orrimmx : OP::orrimmw;
@@ -586,13 +566,13 @@ TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *
     return new (cg->trHeapMemory()) TR::ARM64Trg1ZeroImmInstruction(op, node, treg, N, imm, cg);
 }
 
-TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced)
 {
-    return generateMulInstruction(cg, node, treg, s1reg, s2reg, node->getDataType().isInt64(), preced);
+    return Inst_Mul(cg, node, treg, s1reg, s2reg, node->getDataType().isInt64(), preced);
 }
 
-TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of MADD instruction */
@@ -604,8 +584,8 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
     return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, cg);
 }
 
-TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_CSet(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
+    bool is64bit, TR::Instruction *preced)
 {
     /* Alias of CSINC instruction with inverted condition code */
     OP::Mnemonic op = is64bit ? OP::csincx : OP::csincw;
@@ -615,68 +595,65 @@ TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, 
     return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), cg);
 }
 
-TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_CInc(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced)
 {
     /* Alias of CSINC instruction with inverted condition code */
     OP::Mnemonic op = is64bit ? OP::csincx : OP::csincw;
-    return generateCondTrg1Src2Instruction(cg, op, node, treg, sreg, sreg, cc_invert(cc), preced);
+    return Inst_CondTrg1Src2(cg, op, node, treg, sreg, sreg, cc_invert(cc), preced);
 }
 
-TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
-    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced)
+TR::ARM64SynchronizationInstruction *Inst_Synchronization(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    OP::AArch64BarrierLimitation lim, TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, lim, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, lim, cg);
 }
 
-TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uint32_t imm, TR::Instruction *preced)
+TR::ARM64ExceptionInstruction *Inst_Exception(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+    TR::Instruction *preced)
 {
     if (preced)
         return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, preced, cg);
     return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, cg);
 }
 
-TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_UBFX(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced)
 {
     uint32_t imms = (lsb + width - 1);
     uint32_t immr = lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms,
-        preced);
+    return Inst_Trg1Src1Imm(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms, preced);
 }
 
-TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_UBFIZ(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced)
 {
     uint32_t imms = width - 1;
     uint32_t immr = (is64bit ? 64 : 32) - lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for ubfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms,
-        preced);
+    return Inst_Trg1Src1Imm(cg, is64bit ? OP::ubfmx : OP::ubfmw, node, treg, sreg, (immr << 6) | imms, preced);
 }
 
-TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced)
+TR::Instruction *Inst_BFI(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced)
 {
     uint32_t imms = width - 1;
     uint32_t immr = (is64bit ? 64 : 32) - lsb;
     TR_ASSERT_FATAL((is64bit && (immr <= 63) && (imms <= 63)) || ((!is64bit) && (immr <= 31) && (imms <= 31)),
         "immediate field for bfm is out of range: is64bit=%d, immr=%d, imms=%d", is64bit, immr, imms);
-    return generateTrg1Src1ImmInstruction(cg, is64bit ? OP::bfmx : OP::bfmw, node, treg, sreg, (immr << 6) | imms,
-        preced);
+    return Inst_Trg1Src1Imm(cg, is64bit ? OP::bfmx : OP::bfmw, node, treg, sreg, (immr << 6) | imms, preced);
 }
 
-TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
+TR::Instruction *Inst_VectorShiftImmediate(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vshl16b) && (op <= OP::vsri2d),
-        "Illegal opcode for generateVectorShiftImmediateInstruction: %d", op);
+        "Illegal opcode for Inst_VectorShiftImmediate: %d", op);
 
     bool isShiftLeft = (op <= OP::vsli2d);
     const auto opcodeBinaryEncoding = OP::getOpCodeBinaryEncoding(op);
@@ -693,13 +670,13 @@ TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, 
         "Illegal shift amount: %d", shiftAmount);
 
     uint32_t imm = isShiftLeft ? (shiftAmount + elementSize) : (elementSize * 2 - shiftAmount);
-    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm, preced);
+    return Inst_Trg1Src1Imm(cg, op, node, treg, sreg, imm, preced);
 }
 
-TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, bool isUXTL2, TR::Instruction *preced)
+TR::Instruction *Inst_VectorUXTL(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, bool isUXTL2, TR::Instruction *preced)
 {
-    OP::Mnemonic op;
+    OP::Mnemonic op = OP::bad;
     switch (elementType) {
         case TR::Int8:
             op = isUXTL2 ? OP::vushll2_8h : OP::vushll_8h;
@@ -714,7 +691,7 @@ TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataTy
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
             break;
     }
-    return generateVectorShiftImmediateInstruction(cg, op, node, treg, sreg, 0, preced);
+    return Inst_VectorShiftImmediate(cg, op, node, treg, sreg, 0, preced);
 }
 
 static bool isVectorRegister(TR::Register *reg)
@@ -722,11 +699,11 @@ static bool isVectorRegister(TR::Register *reg)
     return (reg->getRealRegister() != NULL) ? (reg->getKind() == TR_FPR) : (reg->getKind() == TR_VRF);
 }
 
-TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
+TR::Instruction *Inst_VectorDupElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vdupe16b) && (op <= OP::vdupe2d),
-        "Illegal opcode for generateVectorDupElementInstruction: %d", op);
+        "Illegal opcode for Inst_VectorDupElement: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && isVectorRegister(sreg),
         "The target and source register must be VRF");
     const uint32_t elementSizeShift = op - OP::vdupe16b;
@@ -735,14 +712,14 @@ TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::
         "srcIndex (%d) must be less than the number of elements (%d)", srcIndex, nelements);
 
     uint32_t imm5 = (srcIndex << (elementSizeShift + 1)) & 0x1f;
-    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
+    return Inst_Trg1Src1Imm(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
+TR::Instruction *Inst_MovVectorElementToGPR(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::smovwb) && (op <= OP::umovxd),
-        "Illegal opcode for generateMovVectorElementToGPRInstruction: %d", op);
+        "Illegal opcode for Inst_MovVectorElementToGPR: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, (treg->getKind() == TR_GPR) && isVectorRegister(sreg),
         "The target register must be GPR and the source register must be VRF");
     const uint32_t elementSizeShift
@@ -752,14 +729,14 @@ TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg,
         "srcIndex (%d) must be less than the number of elements (%d)", srcIndex, nelements);
 
     uint32_t imm5 = (srcIndex << (elementSizeShift + 1)) & 0x1f;
-    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
+    return Inst_Trg1Src1Imm(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced)
+TR::Instruction *Inst_MovGPRToVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vinswb) && (op <= OP::vinsxd),
-        "Illegal opcode for generateMovGPRToVectorElementInstruction: %d", op);
+        "Illegal opcode for Inst_MovGPRToVectorElement: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && (sreg->getKind() == TR_GPR),
         "The target register must be VRF and the source register must be GPR");
     const uint32_t elementSizeShift = op - OP::vinswb;
@@ -768,14 +745,14 @@ TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg,
         "trgIndex (%d) must be less than the number of elements (%d)", trgIndex, nelements);
 
     uint32_t imm5 = (trgIndex << (elementSizeShift + 1)) & 0x1f;
-    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm5, preced);
+    return Inst_Trg1Src1Imm(cg, op, node, treg, sreg, imm5, preced);
 }
 
-TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced)
+TR::Instruction *Inst_MovVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced)
 {
     TR_ASSERT_FATAL_WITH_NODE(node, (op >= OP::vinseb) && (op <= OP::vinsed),
-        "Illegal opcode for generateMovVectorElementInstruction: %d", op);
+        "Illegal opcode for Inst_MovVectorElement: %d", op);
     TR_ASSERT_FATAL_WITH_NODE(node, isVectorRegister(treg) && isVectorRegister(sreg),
         "The target and source register must be VRF");
     const uint32_t elementSizeShift = op - OP::vinseb;
@@ -797,7 +774,7 @@ TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::
      * +------+--------------+--+-----------+
      */
     uint32_t imm = (imm5 << 5) | imm4;
-    return generateTrg1Src1ImmInstruction(cg, op, node, treg, sreg, imm, preced);
+    return Inst_Trg1Src1Imm(cg, op, node, treg, sreg, imm, preced);
 }
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -51,8 +51,13 @@ class SymbolReference;
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Instruction *preced = NULL);
+TR::Instruction *Inst(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Instruction *preced = NULL)
+{
+    return Inst(cg, op, node, preced);
+}
 
 /*
  * @brief Generates imm instruction
@@ -63,8 +68,14 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+TR::ARM64ImmInstruction *Inst_Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
     TR::Instruction *preced = NULL);
+
+inline TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_Imm(cg, op, node, imm, preced);
+}
 
 /*
  * @brief Generates relocatable imm instruction
@@ -76,8 +87,14 @@ TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, OP::Mnemo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced = NULL)
+{
+    return Inst_RelocatableImm(cg, op, node, imm, relocationKind, preced);
+}
 
 /*
  * @brief Generates relocatable imm instruction
@@ -90,9 +107,15 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mn
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_RelocatableImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     uintptr_t imm, TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr,
-    TR::Instruction *preced = NULL);
+    TR::Instruction *preced = NULL)
+{
+    return Inst_RelocatableImm(cg, op, node, imm, relocationKind, sr, preced);
+}
 
 /*
  * @brief Generates imm sym instruction
@@ -106,8 +129,14 @@ TR::Instruction *generateRelocatableImmInstruction(TR::CodeGenerator *cg, OP::Mn
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+TR::Instruction *Inst_ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
     TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uintptr_t imm,
+    TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s, TR::Instruction *preced = NULL)
+{
+    return Inst_ImmSym(cg, op, node, imm, cond, sr, s, preced);
+}
 
 /*
  * @brief Generates label instruction
@@ -118,8 +147,14 @@ TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic o
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
+{
+    return Inst_Label(cg, op, node, sym, preced);
+}
 
 /*
  * @brief Generates label instruction with register dependency
@@ -131,8 +166,14 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_Label(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::LabelSymbol *sym,
     TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
+{
+    return Inst_Label(cg, op, node, sym, cond, preced);
+}
 
 /*
  * @brief Generates conditional branch instruction
@@ -143,8 +184,14 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL)
+{
+    return Inst_ConditionalBranch(cg, node, sym, cc, preced);
+}
 
 /*
  * @brief Generates conditional branch instruction with register dependency
@@ -156,9 +203,16 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
+TR::Instruction *Inst_ConditionalBranch(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *sym,
     TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
 
+inline TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond,
+    TR::Instruction *preced = NULL)
+{
+    return Inst_ConditionalBranch(cg, node, sym, cc, cond, preced);
+}
+
 /*
  * @brief Generates compare and branch instruction
  * @param[in] cg : CodeGenerator
@@ -169,8 +223,14 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *sreg, TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
+{
+    return Inst_CompareBranch(cg, op, node, sreg, sym, preced);
+}
 
 /*
  * @brief Generates compare and branch instruction
@@ -183,8 +243,34 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mne
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_CompareBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *sreg, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
+{
+    return Inst_CompareBranch(cg, op, node, sreg, sym, cond, preced);
+}
+
+/*
+ * @brief Generates test bit and branch instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] sreg : source register
+ * @param[in] bitpos : bit position
+ * @param[in] sym : label symbol
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL)
+{
+    return Inst_TestBitBranch(cg, op, node, sreg, bitpos, sym, preced);
+}
 
 /*
  * @brief Generates test bit and branch instruction
@@ -198,23 +284,15 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, OP::Mne
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_TestBitBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *sreg,
+    uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond,
-    TR::Instruction *preced = NULL);
-
-/*
- * @brief Generates test bit and branch instruction
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] sreg : source register
- * @param[in] bitpos : bit position
- * @param[in] sym : label symbol
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *sreg, uint32_t bitpos, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+    TR::Instruction *preced = NULL)
+{
+    return Inst_TestBitBranch(cg, op, node, sreg, bitpos, sym, cond, preced);
+}
 
 /*
  * @brief Generates branch-to-register instruction
@@ -225,8 +303,14 @@ TR::Instruction *generateTestBitBranchInstruction(TR::CodeGenerator *cg, OP::Mne
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Instruction *preced = NULL)
+{
+    return Inst_RegBranch(cg, op, node, treg, preced);
+}
 
 /*
  * @brief Generates branch-to-register instruction with register dependency
@@ -238,8 +322,14 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemoni
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_RegBranch(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL)
+{
+    return Inst_RegBranch(cg, op, node, treg, cond, preced);
+}
 
 /*
  * @brief Generates admin instruction
@@ -250,8 +340,14 @@ TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, OP::Mnemoni
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Node *fenceNode = NULL,
+    TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
+{
+    return Inst_Admin(cg, op, node, fenceNode, preced);
+}
 
 /*
  * @brief Generates admin instruction with register dependency
@@ -263,20 +359,14 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_Admin(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL);
 
-/*
- * @brief Generates trg instruction
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] treg : target register
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
-    TR::Instruction *preced = NULL);
+inline TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::RegisterDependencyConditions *cond, TR::Node *fenceNode = NULL, TR::Instruction *preced = NULL)
+{
+    return Inst_Admin(cg, op, node, cond, fenceNode, preced);
+}
 
 /*
  * @brief Generates imm-to-trg instruction
@@ -288,11 +378,17 @@ TR::Instruction *generateTrgInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
-    uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg, uint32_t imm,
+    TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Imm(cg, op, node, treg, imm, preced);
+}
 
 /*
- * @brief Generates shifted imm--to-trg instruction
+ * @brief Generates shifted imm-to-trg instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode
  * @param[in] node : node
@@ -302,8 +398,14 @@ TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1ImmShifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, uint32_t imm, uint32_t shiftAmount, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1ImmShifted(cg, op, node, treg, imm, shiftAmount, preced);
+}
 
 /*
  * @brief Generates imm-to-trg label instruction
@@ -316,8 +418,14 @@ TR::Instruction *generateTrg1ImmShiftedInstruction(TR::CodeGenerator *cg, OP::Mn
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1ImmSym(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1ImmSym(cg, op, node, treg, imm, sym, preced);
+}
 
 /*
  * @brief Generates src1-to-trg instruction
@@ -329,8 +437,14 @@ TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, OP::Mnemon
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src1(cg, op, node, treg, s1reg, preced);
+}
 
 /*
  * @brief Generates src1-and-imm-to-trg instruction
@@ -343,8 +457,14 @@ TR::Instruction *generateTrg1Src1Instruction(TR::CodeGenerator *cg, OP::Mnemonic
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1Src1Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src1Imm(cg, op, node, treg, s1reg, imm, preced);
+}
 
 /*
  * @brief Generates src2-to-trg instruction
@@ -357,24 +477,14 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, OP::Mnemo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
 
-/*
- * @brief Generates src2-to-trg instruction (Conditional register)
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] treg : target register
- * @param[in] s1reg : source register 1
- * @param[in] s2reg : source register 2
- * @param[in] cc : branch condition code
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
-    TR::Instruction *preced = NULL);
+inline TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src2(cg, op, node, treg, s1reg, s2reg, preced);
+}
 
 /*
  * @brief Generates src2-to-trg instruction (Conditional register)
@@ -385,13 +495,18 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnem
  * @param[in] s1reg : source register 1
  * @param[in] s2reg : source register 2
  * @param[in] cc : branch condition code
- * @param[in] cond : Register Dependency Condition
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+TR::Instruction *Inst_CondTrg1Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
     TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ConditionCode cc,
-    TR::RegisterDependencyConditions *cond, TR::Instruction *preced = NULL);
+    TR::Instruction *preced = NULL)
+{
+    return Inst_CondTrg1Src2(cg, op, node, treg, s1reg, s2reg, cc, preced);
+}
 
 /*
  * @brief Generates src2-to-trg imm instruction
@@ -405,8 +520,14 @@ TR::Instruction *generateCondTrg1Src2Instruction(TR::CodeGenerator *cg, OP::Mnem
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1Src2Imm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src2Imm(cg, op, node, treg, s1reg, s2reg, imm, preced);
+}
 
 /*
  * @brief Generates src2-to-trg instruction (shifted register)
@@ -421,9 +542,16 @@ TR::Instruction *generateTrg1Src2ImmInstruction(TR::CodeGenerator *cg, OP::Mnemo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
+TR::Instruction *Inst_Trg1Src2Shifted(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ShiftCode shiftType, uint32_t shiftAmount,
+    TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src2Shifted(cg, op, node, treg, s1reg, s2reg, shiftType, shiftAmount, preced);
+}
 
 /*
  * @brief Generates src2-to-trg instruction (extended register)
@@ -438,9 +566,16 @@ TR::Instruction *generateTrg1Src2ShiftedInstruction(TR::CodeGenerator *cg, OP::M
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
+TR::Instruction *Inst_Trg1Src2Extended(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
     TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::ARM64ExtendCode extendType, uint32_t shiftAmount,
+    TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src2Extended(cg, op, node, treg, s1reg, s2reg, extendType, shiftAmount, preced);
+}
 
 /*
  * @brief Generates src2-to-trg indexed element instruction
@@ -454,8 +589,15 @@ TR::Instruction *generateTrg1Src2ExtendedInstruction(TR::CodeGenerator *cg, OP::
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1Src2IndexedElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, uint32_t index, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
+    TR::Node *node, TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, uint32_t index,
+    TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src2IndexedElement(cg, op, node, treg, s1reg, s2reg, index, preced);
+}
 
 /*
  * @brief Generates src3-to-trg instruction
@@ -469,8 +611,14 @@ TR::Instruction *generateTrg1Src2IndexedElementInstruction(TR::CodeGenerator *cg
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Src3(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *s3reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Src3(cg, op, node, treg, s1reg, s2reg, s3reg, preced);
+}
 
 /*
  * @brief Generates mem-to-trg instruction
@@ -482,8 +630,14 @@ TR::Instruction *generateTrg1Src3Instruction(TR::CodeGenerator *cg, OP::Mnemonic
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_Trg1Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
     TR::MemoryReference *mr, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::MemoryReference *mr, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1Mem(cg, op, node, treg, mr, preced);
+}
 
 /*
  * @brief Generates mem-to-trg2 instruction
@@ -496,8 +650,14 @@ TR::Instruction *generateTrg1MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
+TR::Instruction *Inst_Trg2Mem(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg1,
     TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg1, TR::Register *treg2, TR::MemoryReference *mr, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg2Mem(cg, op, node, treg1, treg2, mr, preced);
+}
 
 /*
  * @brief Generates mem-imm instruction
@@ -509,8 +669,14 @@ TR::Instruction *generateTrg2MemInstruction(TR::CodeGenerator *cg, OP::Mnemonic 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MemImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    uint32_t imm, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::MemoryReference *mr, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_MemImm(cg, op, node, mr, imm, preced);
+}
 
 /*
  * @brief Generates src-to-mem instruction
@@ -522,8 +688,14 @@ TR::Instruction *generateMemImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic o
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    TR::Register *sreg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL)
+{
+    return Inst_MemSrc1(cg, op, node, mr, sreg, preced);
+}
 
 /*
  * @brief Generates src2-to-mem instruction
@@ -536,8 +708,14 @@ TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MemSrc2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::MemoryReference *mr, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
+{
+    return Inst_MemSrc2(cg, op, node, mr, s1reg, s2reg, preced);
+}
 
 /*
  * @brief Generates "store exclusive" instruction
@@ -550,8 +728,14 @@ TR::Instruction *generateMemSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Trg1MemSrc1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced = NULL)
+{
+    return Inst_Trg1MemSrc1(cg, op, node, treg, mr, sreg, preced);
+}
 
 /*
  * @brief Generates src1 instruction
@@ -562,8 +746,14 @@ TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemo
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+TR::Instruction *Inst_Src1(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *s1reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Src1(cg, op, node, s1reg, preced);
+}
 
 /*
  * @brief Generates src2 instruction
@@ -575,8 +765,14 @@ TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, OP::Mnemonic op,
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
+TR::Instruction *Inst_Src2(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Src2(cg, op, node, s1reg, s2reg, preced);
+}
 
 /*
  * @brief Generates ASR instruction
@@ -589,8 +785,14 @@ TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, OP::Mnemonic op,
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_ArithmeticShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_ArithmeticShiftRightImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
+}
 
 /*
  * @brief Generates LSR instruction
@@ -603,8 +805,14 @@ TR::Instruction *generateArithmeticShiftRightImmInstruction(TR::CodeGenerator *c
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+TR::Instruction *Inst_LogicalShiftRightImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
     TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_LogicalShiftRightImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
+}
 
 /*
  * @brief Generates LSL instruction
@@ -617,8 +825,14 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(TR::CodeGenerator *cg, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_LogicalShiftLeftImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+    uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_LogicalShiftLeftImm(cg, node, treg, sreg, shiftAmount, is64bit, preced);
+}
 
 /*
  * @brief Generates logical immediate instruction
@@ -632,8 +846,14 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(TR::CodeGenerator *cg, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_LogicalImm(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *s1reg, bool N, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_LogicalImm(cg, op, node, treg, s1reg, N, imm, preced);
+}
 
 /*
  * @brief Generates CMP (immediate) instruction
@@ -645,8 +865,14 @@ TR::Instruction *generateLogicalImmInstruction(TR::CodeGenerator *cg, OP::Mnemon
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
+TR::Instruction *Inst_CompareImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
     bool is64bit = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
+    int32_t imm, bool is64bit = false, TR::Instruction *preced = NULL)
+{
+    return Inst_CompareImm(cg, node, sreg, imm, is64bit, preced);
+}
 
 /*
  * @brief Generates CMP (register) instruction
@@ -658,8 +884,14 @@ TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Compare(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    bool is64bit = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
+    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL)
+{
+    return Inst_Compare(cg, node, s1reg, s2reg, is64bit, preced);
+}
 
 /**
  * @brief Generates CCMP or CCMN (immediate) instruction
@@ -675,9 +907,16 @@ TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *nod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
-    uint32_t imm, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false, bool isNegative = false,
+TR::Instruction *Inst_ConditionalCompareImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, uint32_t imm,
+    uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false, bool isNegative = false,
     TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::Register *sreg, uint32_t imm, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
+    bool isNegative = false, TR::Instruction *preced = NULL)
+{
+    return Inst_ConditionalCompareImm(cg, node, sreg, imm, conditionFlags, cc, is64bit, isNegative, preced);
+}
 
 /**
  * @brief Generates CCMP or CCMN (register) instruction
@@ -693,9 +932,16 @@ TR::Instruction *generateConditionalCompareImmInstruction(TR::CodeGenerator *cg,
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg1,
+TR::Instruction *Inst_ConditionalCompare(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg1,
     TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
     bool isNegative = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR::Node *node,
+    TR::Register *sreg1, TR::Register *sreg2, uint32_t conditionFlags, TR::ARM64ConditionCode cc, bool is64bit = false,
+    bool isNegative = false, TR::Instruction *preced = NULL)
+{
+    return Inst_ConditionalCompare(cg, node, sreg1, sreg2, conditionFlags, cc, is64bit, isNegative, preced);
+}
 
 /*
  * @brief Generates TST (immediate) instruction
@@ -708,8 +954,14 @@ TR::Instruction *generateConditionalCompareInstruction(TR::CodeGenerator *cg, TR
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm,
-    bool N = false, bool is64bit = false, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_TestImm(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg, int32_t imm, bool N = false,
+    bool is64bit = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *sreg,
+    int32_t imm, bool N = false, bool is64bit = false, TR::Instruction *preced = NULL)
+{
+    return Inst_TestImm(cg, node, sreg, imm, N, is64bit, preced);
+}
 
 /*
  * @brief Generates TST (register) instruction
@@ -721,8 +973,14 @@ TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *nod
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
-    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_Test(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg, TR::Register *s2reg,
+    bool is64bit = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *s1reg,
+    TR::Register *s2reg, bool is64bit = false, TR::Instruction *preced = NULL)
+{
+    return Inst_Test(cg, node, s1reg, s2reg, is64bit, preced);
+}
 
 /*
  * @brief Generates MOV (register) instruction
@@ -734,8 +992,14 @@ TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_Mov(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_Mov(cg, node, treg, sreg, is64bit, preced);
+}
 
 /*
  * @brief Generates MVN (register) instruction
@@ -747,8 +1011,14 @@ TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_Mvn(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_Mvn(cg, node, treg, sreg, is64bit, preced);
+}
 
 /*
  * @brief Generates NEG (register) instruction
@@ -760,8 +1030,14 @@ TR::Instruction *generateMvnInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_Neg(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     bool is64bit = false, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, bool is64bit = false, TR::Instruction *preced = NULL)
+{
+    return Inst_Neg(cg, node, treg, sreg, is64bit, preced);
+}
 
 /*
  * @brief Generates MOV (bitmask immediate) instruction
@@ -774,8 +1050,14 @@ TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N,
-    uint32_t imm, bool is64bit = true, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MovBitMask(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N, uint32_t imm,
+    bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, bool N,
+    uint32_t imm, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_MovBitMask(cg, node, treg, N, imm, is64bit, preced);
+}
 
 /*
  * @brief Generates MUL (register) instruction
@@ -787,8 +1069,14 @@ TR::Instruction *generateMovBitMaskInstruction(TR::CodeGenerator *cg, TR::Node *
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced = NULL)
+{
+    return Inst_Mul(cg, node, treg, s1reg, s2reg, preced);
+}
 
 /*
  * @brief Generates MUL (register) instruction
@@ -801,8 +1089,14 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
+TR::Instruction *Inst_Mul(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *s1reg,
     TR::Register *s2reg, bool is64bit, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *s1reg, TR::Register *s2reg, bool is64bit, TR::Instruction *preced = NULL)
+{
+    return Inst_Mul(cg, node, treg, s1reg, s2reg, is64bit, preced);
+}
 
 /*
  * @brief Generates CSET instruction
@@ -814,8 +1108,14 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
-    TR::ARM64ConditionCode cc, bool is64bit = true, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_CSet(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::ARM64ConditionCode cc,
+    bool is64bit = true, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::ARM64ConditionCode cc, bool is64bit = true, TR::Instruction *preced = NULL)
+{
+    return Inst_CSet(cg, node, treg, cc, is64bit, preced);
+}
 
 /*
  * @brief Generates CINC instruction
@@ -828,8 +1128,14 @@ TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
+TR::Instruction *Inst_CInc(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
     TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, TR::ARM64ConditionCode cc, bool is64bit, TR::Instruction *preced = NULL)
+{
+    return Inst_CInc(cg, node, treg, sreg, cc, is64bit, preced);
+}
 
 /*
  * @brief Generates data synchronization instruction
@@ -840,8 +1146,14 @@ TR::Instruction *generateCIncInstruction(TR::CodeGenerator *cg, TR::Node *node, 
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
-    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL);
+TR::ARM64SynchronizationInstruction *Inst_Synchronization(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL);
+
+inline TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
+    TR::Node *node, OP::AArch64BarrierLimitation lim, TR::Instruction *preced = NULL)
+{
+    return Inst_Synchronization(cg, op, node, lim, preced);
+}
 
 /*
  * @brief Generates exception generating instruction
@@ -852,8 +1164,14 @@ TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::Code
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    uint32_t imm, TR::Instruction *preced = NULL);
+TR::ARM64ExceptionInstruction *Inst_Exception(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, uint32_t imm,
+    TR::Instruction *preced = NULL);
+
+inline TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *cg, OP::Mnemonic op,
+    TR::Node *node, uint32_t imm, TR::Instruction *preced = NULL)
+{
+    return Inst_Exception(cg, op, node, imm, preced);
+}
 
 /**
  * @brief Generates ubfx instruction
@@ -873,8 +1191,14 @@ TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *c
  * @param[in] preced  : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_UBFX(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
+{
+    return Inst_UBFX(cg, node, treg, sreg, lsb, width, is64bit, preced);
+}
 
 /**
  * @brief Generates ubfiz instruction
@@ -894,8 +1218,14 @@ TR::Instruction *generateUBFXInstruction(TR::CodeGenerator *cg, TR::Node *node, 
  * @param[in] preced  : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_UBFIZ(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
+{
+    return Inst_UBFIZ(cg, node, treg, sreg, lsb, width, is64bit, preced);
+}
 
 /**
  * @brief Generates bfi instruction
@@ -915,8 +1245,14 @@ TR::Instruction *generateUBFIZInstruction(TR::CodeGenerator *cg, TR::Node *node,
  * @param[in] preced  : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg,
-    uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_BFI(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg, TR::Register *sreg, uint32_t lsb,
+    uint32_t width, bool is64bit, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t lsb, uint32_t width, bool is64bit, TR::Instruction *preced = NULL)
+{
+    return Inst_BFI(cg, node, treg, sreg, lsb, width, is64bit, preced);
+}
 
 /**
  * @brief Generates vector shift left immediate instruction
@@ -930,8 +1266,14 @@ TR::Instruction *generateBFIInstruction(TR::CodeGenerator *cg, TR::Node *node, T
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_VectorShiftImmediate(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t shiftAmount, TR::Instruction *preced = NULL)
+{
+    return Inst_VectorShiftImmediate(cg, op, node, treg, sreg, shiftAmount, preced);
+}
 
 /**
  * @brief Generates vector unsigned extend long instruction
@@ -945,8 +1287,15 @@ TR::Instruction *generateVectorShiftImmediateInstruction(TR::CodeGenerator *cg, 
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, bool isUXTL2, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_VectorUXTL(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, bool isUXTL2, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataType elementType, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, bool isUXTL2, TR::Instruction *preced = NULL)
+{
+    return Inst_VectorUXTL(cg, elementType, node, treg, sreg, isUXTL2, preced);
+}
+
 /**
  * @brief Generates duplicate vector element instruction
  *
@@ -959,8 +1308,14 @@ TR::Instruction *generateVectorUXTLInstruction(TR::CodeGenerator *cg, TR::DataTy
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_VectorDupElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL)
+{
+    return Inst_VectorDupElement(cg, op, node, treg, sreg, srcIndex, preced);
+}
 
 /**
  * @brief Generates signed or unsigned move vector element to general purpose register instruction
@@ -974,8 +1329,14 @@ TR::Instruction *generateVectorDupElementInstruction(TR::CodeGenerator *cg, OP::
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MovVectorElementToGPR(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t srcIndex, TR::Instruction *preced = NULL)
+{
+    return Inst_MovVectorElementToGPR(cg, op, node, treg, sreg, srcIndex, preced);
+}
 
 /**
  * @brief Generates move general purpose register to vector element instruction
@@ -989,8 +1350,14 @@ TR::Instruction *generateMovVectorElementToGPRInstruction(TR::CodeGenerator *cg,
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MovGPRToVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, TR::Instruction *preced = NULL)
+{
+    return Inst_MovGPRToVectorElement(cg, op, node, treg, sreg, trgIndex, preced);
+}
 
 /**
  * @brief Generates move vector element instruction
@@ -1005,8 +1372,14 @@ TR::Instruction *generateMovGPRToVectorElementInstruction(TR::CodeGenerator *cg,
  * @param[in] preced      : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
-    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL);
+TR::Instruction *Inst_MovVectorElement(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node, TR::Register *treg,
+    TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL);
+
+inline TR::Instruction *generateMovVectorElementInstruction(TR::CodeGenerator *cg, OP::Mnemonic op, TR::Node *node,
+    TR::Register *treg, TR::Register *sreg, uint32_t trgIndex, uint32_t srcIndex, TR::Instruction *preced = NULL)
+{
+    return Inst_MovVectorElement(cg, op, node, treg, sreg, trgIndex, srcIndex, preced);
+}
 
 #ifdef J9_PROJECT_SPECIFIC
 /*

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -219,7 +219,7 @@ void OMR::ARM64::CodeGenerator::beginInstructionSelection()
     TR::Compilation *comp = self()->comp();
     TR::Node *startNode = comp->getStartTree()->getNode();
     if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private) {
-        _returnTypeInfoInstruction = generateImmInstruction(self(), OP::dd, startNode, 0);
+        _returnTypeInfoInstruction = Inst_Imm(self(), OP::dd, startNode, 0);
     } else {
         _returnTypeInfoInstruction = NULL;
     }
@@ -446,7 +446,7 @@ TR::Register *OMR::ARM64::CodeGenerator::gprClobberEvaluate(TR::Node *node)
             targetReg->setPinningArrayPointer(resultReg->getPinningArrayPointer());
         }
 
-        generateMovInstruction(self(), node, targetReg, resultReg);
+        Inst_Mov(self(), node, targetReg, resultReg);
         return targetReg;
     } else {
         return resultReg;
@@ -841,9 +841,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src1ImmInstruction(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
-    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
+    cursor = Inst_Trg1Mem(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = Inst_Trg1Src1Imm(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
+    cursor = Inst_MemSrc1(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     if (cond) {
         TR::addDependency(cond, addrReg, TR::RealRegister::NoReg, TR_GPR, self());
@@ -867,9 +867,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src2Instruction(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
-    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
+    cursor = Inst_Trg1Mem(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = Inst_Trg1Src2(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
+    cursor = Inst_MemSrc1(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     if (cond) {
         TR::addDependency(cond, addrReg, TR::RealRegister::NoReg, TR_GPR, self());
@@ -902,9 +902,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src1ImmInstruction(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
-    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
+    cursor = Inst_Trg1Mem(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = Inst_Trg1Src1Imm(self(), OP::addimmw, node, counterReg, counterReg, delta, cursor);
+    cursor = Inst_MemSrc1(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
 
     srm.reclaimScratchRegister(addrReg);
     srm.reclaimScratchRegister(counterReg);
@@ -924,9 +924,9 @@ TR::Instruction *OMR::ARM64::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
     cursor
         = loadAddressConstant(self(), comp()->compileRelocatableCode(), node, addr, addrReg, cursor, TR_DebugCounter);
-    cursor = generateTrg1MemInstruction(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
-    cursor = generateTrg1Src2Instruction(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
-    cursor = generateMemSrc1Instruction(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
+    cursor = Inst_Trg1Mem(self(), OP::ldrimmw, node, counterReg, MRef_disp(self(), addrReg, 0), cursor);
+    cursor = Inst_Trg1Src2(self(), OP::addw, node, counterReg, counterReg, deltaReg, cursor);
+    cursor = Inst_MemSrc1(self(), OP::strimmw, node, MRef_disp(self(), addrReg, 0), counterReg, cursor);
     srm.reclaimScratchRegister(addrReg);
     srm.reclaimScratchRegister(counterReg);
     return cursor;

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -515,8 +515,8 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
 
                 // ai := stack
                 TR::MemoryReference *stackMR = MRef_disp(cg(), stackPtr, offset);
-                loadCursor = generateTrg1MemInstruction(cg(), getOpCodeForParmLoads(paramType), NULL,
-                    machine->getRealRegister(ai), stackMR, loadCursor);
+                loadCursor = Inst_Trg1Mem(cg(), getOpCodeForParmLoads(paramType), NULL, machine->getRealRegister(ai),
+                    stackMR, loadCursor);
             }
         } else // It's in a linkage register
         {
@@ -537,8 +537,7 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
 
                     TR::RealRegister *linkageReg = machine->getRealRegister(sourceIndex);
                     TR::MemoryReference *stackMR = MRef_disp(cg(), stackPtr, offset);
-                    cursor = generateMemSrc1Instruction(cg(), getOpCodeForParmStores(paramType), NULL, stackMR,
-                        linkageReg, cursor);
+                    cursor = Inst_MemSrc1(cg(), getOpCodeForParmStores(paramType), NULL, stackMR, linkageReg, cursor);
                 }
             }
 
@@ -621,12 +620,12 @@ TR::Instruction *OMR::ARM64::Linkage::copyParametersToHomeLocation(TR::Instructi
                 TR::Register *trgReg = machine->getRealRegister(regCursor);
                 TR::Register *srcReg = machine->getRealRegister(source);
                 if ((paramType == TR::Double) || (paramType == TR::Float)) {
-                    cursor = generateTrg1Src1Instruction(cg(), (paramType == TR::Double) ? OP::fmovd : OP::fmovs, NULL,
-                        trgReg, srcReg, cursor);
+                    cursor = Inst_Trg1Src1(cg(), (paramType == TR::Double) ? OP::fmovd : OP::fmovs, NULL, trgReg,
+                        srcReg, cursor);
                 } else {
-                    // generateMovInstruction cannot be used in the binary encoding phase because it relies on RegDep
+                    // Inst_Mov cannot be used in the binary encoding phase because it relies on RegDep
                     // for assigning xzr for 1st source register.
-                    cursor = generateTrg1Src2Instruction(cg(),
+                    cursor = Inst_Trg1Src2(cg(),
                         (paramType == TR::Int64) || (paramType == TR::Address) ? OP::orrx : OP::orrw, NULL, trgReg,
                         machine->getRealRegister(TR::RealRegister::xzr), srcReg, cursor);
                 }

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -378,7 +378,7 @@ void OMR::ARM64::Machine::spillRegister(TR::Instruction *currentInstruction, TR:
     }
 
     TR::RealRegister *realReg = toRealRegister(virtReg->getAssignedRegister());
-    generateTrg1MemInstruction(cg, loadOp, currentNode, realReg, tmemref, currentInstruction);
+    Inst_Trg1Mem(cg, loadOp, currentNode, realReg, tmemref, currentInstruction);
 
     cg->traceRegFreed(registerToSpill, realReg);
 
@@ -528,7 +528,7 @@ TR::RealRegister *OMR::ARM64::Machine::reverseSpillState(TR::Instruction *curren
             TR_ASSERT(false, "Unsupported RegisterKind.");
             break;
     }
-    generateMemSrc1Instruction(cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
+    Inst_MemSrc1(cg(), storeOp, currentNode, tmemref, targetRegister, currentInstruction);
 
     return targetRegister;
 }
@@ -587,13 +587,13 @@ static void registerCopy(TR::Instruction *precedingInstruction, TR_RegisterKinds
     TR::Node *node = precedingInstruction->getNode();
     switch (rk) {
         case TR_GPR:
-            generateMovInstruction(cg, node, targetReg, sourceReg, true, precedingInstruction);
+            Inst_Mov(cg, node, targetReg, sourceReg, true, precedingInstruction);
             break;
         case TR_FPR:
-            generateTrg1Src1Instruction(cg, OP::fmovd, node, targetReg, sourceReg, precedingInstruction);
+            Inst_Trg1Src1(cg, OP::fmovd, node, targetReg, sourceReg, precedingInstruction);
             break;
         case TR_VRF:
-            generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, sourceReg, sourceReg, precedingInstruction);
+            Inst_Trg1Src2(cg, OP::vorr16b, node, targetReg, sourceReg, sourceReg, precedingInstruction);
             break;
         default:
             TR_ASSERT(false, "Unsupported RegisterKind.");
@@ -609,13 +609,13 @@ static void registerExchange(TR::Instruction *precedingInstruction, TR_RegisterK
 
     TR::Node *node = precedingInstruction->getNode();
     if (rk == TR_GPR) {
-        generateTrg1Src2Instruction(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
-        generateTrg1Src2Instruction(cg, OP::eorx, node, sourceReg, targetReg, sourceReg, precedingInstruction);
-        generateTrg1Src2Instruction(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::eorx, node, sourceReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::eorx, node, targetReg, targetReg, sourceReg, precedingInstruction);
     } else {
-        generateTrg1Src2Instruction(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
-        generateTrg1Src2Instruction(cg, OP::veor16b, node, sourceReg, targetReg, sourceReg, precedingInstruction);
-        generateTrg1Src2Instruction(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::veor16b, node, sourceReg, targetReg, sourceReg, precedingInstruction);
+        Inst_Trg1Src2(cg, OP::veor16b, node, targetReg, targetReg, sourceReg, precedingInstruction);
     }
 }
 
@@ -1020,7 +1020,7 @@ void OMR::ARM64::Machine::createRegisterAssociationDirective(TR::Instruction *cu
         associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum), regNum);
     }
 
-    generateAdminInstruction(cg(), OP::assocreg, cursor->getNode(), associations, NULL, cursor);
+    Inst_Admin(cg(), OP::assocreg, cursor->getNode(), associations, NULL, cursor);
 }
 
 TR::Register *OMR::ARM64::Machine::setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register *virtReg)

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -77,12 +77,12 @@ static void loadRelocatableConstant(TR::Node *node, TR::SymbolReference *ref, TR
                                         : (uintptr_t)symbol->getMethodSymbol()->getMethodAddress();
 
     if (symbol->isStartPC()) {
-        generateTrg1ImmSymInstruction(cg, OP::adr, node, reg, addr, symbol);
+        Inst_Trg1ImmSym(cg, OP::adr, node, reg, addr, symbol);
         return;
     }
 
     if (symbol->isGCRPatchPoint()) {
-        generateTrg1ImmSymInstruction(cg, OP::adr, node, reg, addr, symbol);
+        Inst_Trg1ImmSym(cg, OP::adr, node, reg, addr, symbol);
         return;
     }
 
@@ -329,13 +329,13 @@ void OMR::ARM64::MemoryReference::validateImmediateOffsetAlignment(TR::Node *nod
 
         if (_baseRegister != NULL) {
             if (constantIsUnsignedImm12(displacement)) {
-                generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
+                Inst_Trg1Src1Imm(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
             } else if (node->getOpCode().isLoadConst() && node->getRegister() && (node->getLongInt() == displacement)) {
-                generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
+                Inst_Trg1Src2(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
             } else {
                 TR::Register *tempReg = cg->allocateRegister();
                 loadConstant64(cg, node, displacement, tempReg);
-                generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, tempReg);
+                Inst_Trg1Src2(cg, OP::addx, node, newBase, _baseRegister, tempReg);
                 cg->stopUsingRegister(tempReg);
             }
         } else {
@@ -391,14 +391,14 @@ void OMR::ARM64::MemoryReference::normalize(TR::Node *node, TR::CodeGenerator *c
 
             if (_baseRegister != NULL) {
                 if (constantIsUnsignedImm12(displacement)) {
-                    generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
+                    Inst_Trg1Src1Imm(cg, OP::addimmx, node, newBase, _baseRegister, displacement);
                 } else if (node->getOpCode().isLoadConst() && node->getRegister()
                     && (node->getLongInt() == displacement)) {
-                    generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
+                    Inst_Trg1Src2(cg, OP::addx, node, newBase, _baseRegister, node->getRegister());
                 } else {
                     TR::Register *tempReg = cg->allocateRegister();
                     loadConstant64(cg, node, displacement, tempReg);
-                    generateTrg1Src2Instruction(cg, OP::addx, node, newBase, _baseRegister, tempReg);
+                    Inst_Trg1Src2(cg, OP::addx, node, newBase, _baseRegister, tempReg);
                     cg->stopUsingRegister(tempReg);
                 }
             } else {
@@ -714,26 +714,26 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Node *srcTree, TR::Co
 
     if (_baseRegister != NULL) {
         if (self()->isIndexZeroExtendedWord()) {
-            generateTrg1Src2ExtendedInstruction(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister,
-                _indexRegister, TR::EXT_UXTW, _scale);
+            Inst_Trg1Src2Extended(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister, _indexRegister,
+                TR::EXT_UXTW, _scale);
         } else if (self()->isIndexSignExtendedWord()) {
-            generateTrg1Src2ExtendedInstruction(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister,
-                _indexRegister, TR::EXT_SXTW, _scale);
+            Inst_Trg1Src2Extended(cg, OP::addextx, srcTree, tempTargetRegister, _baseRegister, _indexRegister,
+                TR::EXT_SXTW, _scale);
         } else {
-            generateTrg1Src2ShiftedInstruction(cg, OP::addx, srcTree, tempTargetRegister, _baseRegister, _indexRegister,
-                TR::SH_LSL, _scale);
+            Inst_Trg1Src2Shifted(cg, OP::addx, srcTree, tempTargetRegister, _baseRegister, _indexRegister, TR::SH_LSL,
+                _scale);
         }
     } else if (_scale != 0) {
-        generateLogicalShiftLeftImmInstruction(cg, srcTree, tempTargetRegister, _indexRegister, _scale, true);
+        Inst_LogicalShiftLeftImm(cg, srcTree, tempTargetRegister, _indexRegister, _scale, true);
         if (self()->isIndexZeroExtendedWord()) {
-            generateTrg1Src1ImmInstruction(cg, OP::ubfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
+            Inst_Trg1Src1Imm(cg, OP::ubfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
         } else if (self()->isIndexSignExtendedWord()) {
-            generateTrg1Src1ImmInstruction(cg, OP::sbfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
+            Inst_Trg1Src1Imm(cg, OP::sbfmx, srcTree, tempTargetRegister, tempTargetRegister, 31);
         }
     } else if (self()->isIndexZeroExtendedWord()) {
-        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, srcTree, tempTargetRegister, _indexRegister, 31);
+        Inst_Trg1Src1Imm(cg, OP::ubfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else if (self()->isIndexSignExtendedWord()) {
-        generateTrg1Src1ImmInstruction(cg, OP::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
+        Inst_Trg1Src1Imm(cg, OP::sbfmx, srcTree, tempTargetRegister, _indexRegister, 31);
     } else {
         TR_ASSERT_FATAL(false,
             "consolidateRegister() expects (_baseRegister != NULL) || (_scale != 0) || isIndexZeroExtendedWord() || "
@@ -1179,7 +1179,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
             }
             cursor += ARM64_INSTRUCTION_LENGTH;
         } else {
-            // loadaddrEvaluator() uses addimmx in generateTrg1MemInstruction
+            // loadaddrEvaluator() uses addimmx in Inst_Trg1Mem
             TR_ASSERT(index == NULL, "MemoryReference with unexpected indexed form");
 
             if (constantIsUnsignedImm12(displacement)) {
@@ -1245,8 +1245,8 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction *currentInstruction,
     TR::CodeGenerator *cg)
 {
-    // Due to the way the generate*Instruction helpers work, there's no way to use them to generate an instruction at
-    // the start of the instruction stream at the moment. As a result, we cannot peform expansion if the first
+    // Due to the way the Inst_* functions work, there's no way to use them to generate an instruction at the
+    // start of the instruction stream at the moment. As a result, we cannot peform expansion if the first
     // instruction is a memory instruction.
     TR_ASSERT_FATAL(currentInstruction->getPrev(), "The first instruction cannot be a memory instruction");
 
@@ -1277,7 +1277,7 @@ TR::Instruction *OMR::ARM64::MemoryReference::expandInstruction(TR::Instruction 
                         if (isImm9UnscaledOffsetInstruction(enc)) {
                             if (isBaseModifiable() && constantIsUnsignedImm12(displacement)) {
                                 TR::Instruction *prev = currentInstruction->getPrev();
-                                generateTrg1Src1ImmInstruction(cg, OP::addimmw, currentInstruction->getNode(),
+                                Inst_Trg1Src1Imm(cg, OP::addimmw, currentInstruction->getNode(),
                                     self()->getBaseRegister(), self()->getBaseRegister(), displacement, prev);
                                 self()->setOffset(0);
                                 return currentInstruction;

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -107,15 +107,14 @@ OMR::ARM64::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeG
                     copyReg->setContainsInternalPointer();
                     copyReg->setPinningArrayPointer(reg->getPinningArrayPointer());
                 }
-                iCursor = generateMovInstruction(cg, node, copyReg, reg, true, iCursor);
+                iCursor = Inst_Mov(cg, node, copyReg, reg, true, iCursor);
             } else if (kind == TR_VRF) {
                 copyReg = cg->allocateRegister(TR_VRF);
-                iCursor = generateTrg1Src2Instruction(cg, OP::vorr16b, node, copyReg, reg, reg, iCursor);
+                iCursor = Inst_Trg1Src2(cg, OP::vorr16b, node, copyReg, reg, reg, iCursor);
             } else {
                 bool isSinglePrecision = reg->isSinglePrecision();
                 copyReg = isSinglePrecision ? cg->allocateSinglePrecisionRegister() : cg->allocateRegister(TR_FPR);
-                iCursor = generateTrg1Src1Instruction(cg, isSinglePrecision ? OP::fmovs : OP::fmovd, node, copyReg, reg,
-                    iCursor);
+                iCursor = Inst_Trg1Src1(cg, isSinglePrecision ? OP::fmovs : OP::fmovd, node, copyReg, reg, iCursor);
             }
 
             reg = copyReg;
@@ -432,8 +431,7 @@ void OMR::ARM64::RegisterDependencyGroup::assignRegisters(TR::Instruction *curre
                         break;
                 }
 
-                TR::Instruction *inst
-                    = generateTrg1MemInstruction(cg, opCode, currentNode, assignedReg, tempMR, currentInstruction);
+                TR::Instruction *inst = Inst_Trg1Mem(cg, opCode, currentNode, assignedReg, tempMR, currentInstruction);
 
                 assignedReg->setAssignedRegister(NULL);
                 virtReg->setAssignedRegister(NULL);

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -878,9 +878,9 @@ static TR::Instruction *tryToGenerateImm16ShiftedInstrucion(TR::Node *node, TR::
     OP::Mnemonic op, uint16_t value)
 {
     if ((value & 0xff00) == 0) {
-        return generateTrg1ImmInstruction(cg, op, node, treg, value & 0xff);
+        return Inst_Trg1Imm(cg, op, node, treg, value & 0xff);
     } else if ((value & 0xff) == 0) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 8) & 0xff, 8);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 8) & 0xff, 8);
     }
     return NULL;
 }
@@ -900,13 +900,13 @@ static TR::Instruction *tryToGenerateImm32ShiftedInstruction(TR::Node *node, TR:
     OP::Mnemonic op, uint32_t value)
 {
     if ((value & 0xffffff00) == 0) {
-        return generateTrg1ImmInstruction(cg, op, node, treg, value & 0xff);
+        return Inst_Trg1Imm(cg, op, node, treg, value & 0xff);
     } else if ((value & 0xffff00ff) == 0) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 8) & 0xff, 8);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 8) & 0xff, 8);
     } else if ((value & 0xff00ffff) == 0) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 16) & 0xff, 16);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 16) & 0xff, 16);
     } else if ((value & 0xffffff) == 0) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 24) & 0xff, 24);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 24) & 0xff, 24);
     }
     return NULL;
 }
@@ -926,9 +926,9 @@ static TR::Instruction *tryToGenerateImm32ShiftingOnesInstruction(TR::Node *node
     TR::Register *treg, OP::Mnemonic op, uint32_t value)
 {
     if ((value & 0xffff00ff) == 0xff) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 8) & 0xff, 8);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 8) & 0xff, 8);
     } else if ((value & 0xff00ffff) == 0xffff) {
-        return generateTrg1ImmShiftedInstruction(cg, op, node, treg, (value >> 16) & 0xff, 16);
+        return Inst_Trg1ImmShifted(cg, op, node, treg, (value >> 16) & 0xff, 16);
     }
     return NULL;
 }
@@ -958,7 +958,7 @@ static TR::Instruction *tryToGenerateImm64Instruction(TR::Node *node, TR::CodeGe
             return NULL;
         }
     }
-    return generateTrg1ImmInstruction(cg, op, node, treg, imm);
+    return Inst_Trg1Imm(cg, op, node, treg, imm);
 }
 
 /**
@@ -977,7 +977,7 @@ static TR::Instruction *tryToGenerateMovImm16ShiftedInstruction(TR::Node *node, 
     uint8_t lower8bit = value & 0xff;
     uint8_t upper8bit = (value >> 8) & 0xff;
     if (lower8bit == upper8bit) {
-        return generateTrg1ImmInstruction(cg, OP::vmovi16b, node, treg, lower8bit);
+        return Inst_Trg1Imm(cg, OP::vmovi16b, node, treg, lower8bit);
     }
 
     TR::Instruction *instr;
@@ -1054,11 +1054,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mmAnyTrueEvaluator(TR::Node *node, TR::
      * cmp   x0, #0
      * cset  x0, ne
      */
-    generateTrg1Src2Instruction(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
-    generateTrg1Src2Instruction(cg, OP::vumaxp4s, node, tempReg, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resultReg, tempReg, 0);
-    generateCompareImmInstruction(cg, node, resultReg, 0, true);
-    generateCSetInstruction(cg, node, resultReg, TR::CC_NE);
+    Inst_Trg1Src2(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
+    Inst_Trg1Src2(cg, OP::vumaxp4s, node, tempReg, tempReg, tempReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resultReg, tempReg, 0);
+    Inst_CompareImm(cg, node, resultReg, 0, true);
+    Inst_CSet(cg, node, resultReg, TR::CC_NE);
 
     cg->stopUsingRegister(tempReg);
     node->setRegister(resultReg);
@@ -1089,11 +1089,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mmAllTrueEvaluator(TR::Node *node, TR::
      * cmn   x0, #1
      * cset  x0, eq
      */
-    generateTrg1Src2Instruction(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
-    generateTrg1Src2Instruction(cg, OP::vuminp4s, node, tempReg, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resultReg, tempReg, 0);
-    generateCompareImmInstruction(cg, node, resultReg, -1, true);
-    generateCSetInstruction(cg, node, resultReg, TR::CC_EQ);
+    Inst_Trg1Src2(cg, OP::vand16b, node, tempReg, maskReg, mask2Reg);
+    Inst_Trg1Src2(cg, OP::vuminp4s, node, tempReg, tempReg, tempReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resultReg, tempReg, 0);
+    Inst_CompareImm(cg, node, resultReg, -1, true);
+    Inst_CSet(cg, node, resultReg, TR::CC_EQ);
 
     cg->stopUsingRegister(tempReg);
     node->setRegister(resultReg);
@@ -1163,9 +1163,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mTrueCountEvaluator(TR::Node *node, TR:
             break;
     }
 
-    generateTrg1Src1Instruction(cg, negOp, node, tempReg, maskReg);
-    generateTrg1Src1Instruction(cg, addvOp, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovwb, node, resReg, tempReg, 0);
+    Inst_Trg1Src1(cg, negOp, node, tempReg, maskReg);
+    Inst_Trg1Src1(cg, addvOp, node, tempReg, tempReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovwb, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1198,11 +1198,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #2                  ; Divides by 4.
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 2, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_Trg1Src1(cg, OP::rbitx, node, resReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 2, true);
             break;
         case TR::Int16:
             /*
@@ -1212,11 +1212,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #3                  ; Divides by 8.
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 3, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_Trg1Src1(cg, OP::rbitx, node, resReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 3, true);
             break;
         case TR::Int32:
             /*
@@ -1226,11 +1226,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     x0, x0                      ; Counts leading zeros.
              * lsr     x0, x0, #4                  ; Divides by 16.
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateTrg1Src1Instruction(cg, OP::rbitx, node, resReg, resReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_Trg1Src1(cg, OP::rbitx, node, resReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 4, true);
             break;
         case TR::Int64:
             /*
@@ -1240,10 +1240,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mFirstTrueEvaluator(TR::Node *node, TR:
              * clz     w0, w0                      ; Counts leading zeros.
              * lsr     w0, w0, #4                  ; Divides by 16.
              */
-            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 2);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 3);
-            generateTrg1Src1Instruction(cg, OP::clzw, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, false);
+            Inst_Trg1Src2Imm(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 2);
+            Inst_MovVectorElementToGPR(cg, OP::umovws, node, resReg, tempReg, 3);
+            Inst_Trg1Src1(cg, OP::clzw, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 4, false);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1283,12 +1283,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #2                  ; Divides by 4.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_8b, node, tempReg, maskReg, 4);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 15, maxLaneReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 2, true);
-            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 2, true);
+            Inst_Trg1Src2(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int16:
             /*
@@ -1299,12 +1299,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #3                  ; Divides by 8.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_4h, node, tempReg, maskReg, 8);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 7, maxLaneReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 3, true);
-            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 3, true);
+            Inst_Trg1Src2(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int32:
             /*
@@ -1315,12 +1315,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #4                  ; Divides by 16.
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_2s, node, tempReg, maskReg, 16);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 3, maxLaneReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 4, true);
-            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 4, true);
+            Inst_Trg1Src2(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         case TR::Int64:
             /*
@@ -1331,12 +1331,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLastTrueEvaluator(TR::Node *node, TR::
              * lsr     x0, x0, #5
              * sub     x0, x1, x0
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 32);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_2s, node, tempReg, maskReg, 32);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
             loadConstant32(cg, node, 1, maxLaneReg);
-            generateTrg1Src1Instruction(cg, OP::clzx, node, resReg, resReg);
-            generateLogicalShiftRightImmInstruction(cg, node, resReg, resReg, 5, true);
-            generateTrg1Src2Instruction(cg, OP::subx, node, resReg, maxLaneReg, resReg);
+            Inst_Trg1Src1(cg, OP::clzx, node, resReg, resReg);
+            Inst_LogicalShiftRightImm(cg, node, resReg, resReg, 5, true);
+            Inst_Trg1Src2(cg, OP::subx, node, resReg, maxLaneReg, resReg);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1375,13 +1375,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #24, #20            ; Inserts bit 0 - 19 into bit 24 - 43.
              * ubfx    x0, x0, #36, #16            ; Moves bit 36 - 51 to bit 0 - 15. Other bits are cleared.
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_8b, node, tempReg, maskReg, 7);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli16b, node, tempReg, tempReg, 6);
-            generateVectorShiftImmediateInstruction(cg, OP::vushr8h, node, tempReg, tempReg, 6);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, tempReg, tempReg, 12);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateBFIInstruction(cg, node, resReg, resReg, 24, 20, true);
-            generateUBFXInstruction(cg, node, resReg, resReg, 36, 16, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_8b, node, tempReg, maskReg, 7);
+            Inst_VectorShiftImmediate(cg, OP::vsli16b, node, tempReg, tempReg, 6);
+            Inst_VectorShiftImmediate(cg, OP::vushr8h, node, tempReg, tempReg, 6);
+            Inst_VectorShiftImmediate(cg, OP::vsli8h, node, tempReg, tempReg, 12);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_BFI(cg, node, resReg, resReg, 24, 20, true);
+            Inst_UBFX(cg, node, resReg, resReg, 36, 16, true);
             break;
         case TR::Int16:
             /*
@@ -1392,11 +1392,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #28, #18            ; Inserts bit 0 - 17 into bit 28 - 45.
              * ubfx    x0, x0, #42, #8             ; Moves bit 42 - 49 to bit 0 - 7.
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_4h, node, tempReg, maskReg, 15);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, tempReg, tempReg, 14);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateBFIInstruction(cg, node, resReg, resReg, 28, 18, true);
-            generateUBFXInstruction(cg, node, resReg, resReg, 42, 8, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_4h, node, tempReg, maskReg, 15);
+            Inst_VectorShiftImmediate(cg, OP::vsli8h, node, tempReg, tempReg, 14);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_BFI(cg, node, resReg, resReg, 28, 18, true);
+            Inst_UBFX(cg, node, resReg, resReg, 42, 8, true);
             break;
         case TR::Int32:
         case TR::Float:
@@ -1406,10 +1406,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * bfi     x0, x0, #30, #2
              * ubfx    x0, x0, #30, #4
              */
-            generateVectorShiftImmediateInstruction(cg, OP::vshrn_2s, node, tempReg, maskReg, 31);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
-            generateBFIInstruction(cg, node, resReg, resReg, 30, 2, true);
-            generateUBFXInstruction(cg, node, resReg, resReg, 30, 4, true);
+            Inst_VectorShiftImmediate(cg, OP::vshrn_2s, node, tempReg, maskReg, 31);
+            Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
+            Inst_BFI(cg, node, resReg, resReg, 30, 2, true);
+            Inst_UBFX(cg, node, resReg, resReg, 30, 4, true);
             break;
         case TR::Int64:
         case TR::Double:
@@ -1418,9 +1418,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::mToLongBitsEvaluator(TR::Node *node, TR
              * umov    w0, v1.4s[0]
              * ubfx    w0, w0, #7, #2
              */
-            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
-            generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 0);
-            generateUBFXInstruction(cg, node, resReg, resReg, 7, 2, false);
+            Inst_Trg1Src2Imm(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
+            Inst_MovVectorElementToGPR(cg, OP::umovws, node, resReg, tempReg, 0);
+            Inst_UBFX(cg, node, resReg, resReg, 7, 2, false);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1463,14 +1463,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * sli     v0.8h, v0.8h, #7            ; Bit 0 of each lane in int8x16 vector have mask values.
              * cmtst   v0.16b, v0.16b, v1.16b      ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 24);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 12);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 6);
-            generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, tempReg, 1);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 7);
-            generateTrg1Src2Instruction(cg, OP::vcmtst16b, node, maskReg, maskReg, tempReg);
+            Inst_Trg1Src1(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            Inst_VectorShiftImmediate(cg, OP::vsli2d, node, maskReg, maskReg, 24);
+            Inst_VectorShiftImmediate(cg, OP::vsli4s, node, maskReg, maskReg, 12);
+            Inst_VectorShiftImmediate(cg, OP::vsli8h, node, maskReg, maskReg, 6);
+            Inst_VectorUXTL(cg, TR::Int8, node, maskReg, maskReg, false);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, tempReg, 1);
+            Inst_VectorShiftImmediate(cg, OP::vsli8h, node, maskReg, maskReg, 7);
+            Inst_Trg1Src2(cg, OP::vcmtst16b, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int16:
             /*
@@ -1485,13 +1485,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * uxtl    v0.8h, v0.8b                ; The lsb of each lane in int16x8 vector has mask values.
              * cmtst   v0.8h, v0.8h, v1.8h         ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 28);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 14);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli8h, node, maskReg, maskReg, 7);
-            generateTrg1ImmInstruction(cg, OP::vmovi8h, node, tempReg, 1);
-            generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-            generateTrg1Src2Instruction(cg, OP::vcmtst8h, node, maskReg, maskReg, tempReg);
+            Inst_Trg1Src1(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            Inst_VectorShiftImmediate(cg, OP::vsli2d, node, maskReg, maskReg, 28);
+            Inst_VectorShiftImmediate(cg, OP::vsli4s, node, maskReg, maskReg, 14);
+            Inst_VectorShiftImmediate(cg, OP::vsli8h, node, maskReg, maskReg, 7);
+            Inst_Trg1Imm(cg, OP::vmovi8h, node, tempReg, 1);
+            Inst_VectorUXTL(cg, TR::Int8, node, maskReg, maskReg, false);
+            Inst_Trg1Src2(cg, OP::vcmtst8h, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int32:
         case TR::Float:
@@ -1505,12 +1505,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * uxtl    v0.4s, v0.4h                ; The lsb of each lane in int32x4 vector has mask values.
              * cmtst   v0.4s, v0.4s, v1.4s         ; Tests if bit 0 of each lane is set
              */
-            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, srcReg);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli2d, node, maskReg, maskReg, 30);
-            generateVectorShiftImmediateInstruction(cg, OP::vsli4s, node, maskReg, maskReg, 15);
-            generateTrg1ImmInstruction(cg, OP::vmovi4s, node, tempReg, 1);
-            generateVectorUXTLInstruction(cg, TR::Int16, node, maskReg, maskReg, false);
-            generateTrg1Src2Instruction(cg, OP::vcmtst4s, node, maskReg, maskReg, tempReg);
+            Inst_Trg1Src1(cg, OP::fmov_xtod, node, maskReg, srcReg);
+            Inst_VectorShiftImmediate(cg, OP::vsli2d, node, maskReg, maskReg, 30);
+            Inst_VectorShiftImmediate(cg, OP::vsli4s, node, maskReg, maskReg, 15);
+            Inst_Trg1Imm(cg, OP::vmovi4s, node, tempReg, 1);
+            Inst_VectorUXTL(cg, TR::Int16, node, maskReg, maskReg, false);
+            Inst_Trg1Src2(cg, OP::vcmtst4s, node, maskReg, maskReg, tempReg);
             break;
         case TR::Int64:
         case TR::Double:
@@ -1522,11 +1522,11 @@ TR::Register *OMR::ARM64::TreeEvaluator::mLongBitsToMaskEvaluator(TR::Node *node
              * cmeq    v0.2d, v0.2d, #0
              * not     v0.16b, v0.16b
              */
-            generateUBFIZInstruction(cg, node, tempReg, srcReg, 55, 2, true);
-            generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, maskReg, tempReg);
-            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 15);
-            generateTrg1Src1Instruction(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
-            generateTrg1Src1Instruction(cg, OP::vnot16b, node, maskReg, maskReg);
+            Inst_UBFIZ(cg, node, tempReg, srcReg, 55, 2, true);
+            Inst_Trg1Src1(cg, OP::fmov_xtod, node, maskReg, tempReg);
+            Inst_Trg1Src2Imm(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 15);
+            Inst_Trg1Src1(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
+            Inst_Trg1Src1(cg, OP::vnot16b, node, maskReg, maskReg);
             break;
         default:
             TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
@@ -1577,25 +1577,25 @@ static TR::Register *mloadiFromArrayHelper(TR::Node *node, TR::CodeGenerator *cg
     TR::MemoryReference *tempMR = MRef_node(cg, node);
     tempMR->validateImmediateOffsetAlignment(node, numElements, cg);
 
-    generateTrg1MemInstruction(cg, loadOp, node, dstReg, tempMR);
+    Inst_Trg1Mem(cg, loadOp, node, dstReg, tempMR);
 
     // unpack byte-length elements to halfword-length elements (for Short, Int/Float, and Long/DoubleVector mask load)
     if (numElements <= 8)
-        generateVectorUXTLInstruction(cg, TR::Int8, node, dstReg, dstReg, false);
+        Inst_VectorUXTL(cg, TR::Int8, node, dstReg, dstReg, false);
 
     // unpack halfword-length elements to word-length elements (for Int/Float and Long/DoubleVector mask load)
     if (numElements <= 4)
-        generateVectorUXTLInstruction(cg, TR::Int16, node, dstReg, dstReg, false);
+        Inst_VectorUXTL(cg, TR::Int16, node, dstReg, dstReg, false);
 
     // unpack word-length elements to doubleword-length elements (for Long/DoubleVector mask load)
     if (numElements == 2)
-        generateVectorUXTLInstruction(cg, TR::Int32, node, dstReg, dstReg, false);
+        Inst_VectorUXTL(cg, TR::Int32, node, dstReg, dstReg, false);
 
     // since OMR assumes that boolean values are represented as 0x00 for false and 0x01 for true, we can create an
     // all 0/1 mask by negation (subtracting from 0):
     // 0-1 = -1 = 0xFF...
     // 0-0 = 0
-    generateTrg1Src1Instruction(cg, negOp, node, dstReg, dstReg);
+    Inst_Trg1Src1(cg, negOp, node, dstReg, dstReg);
 
     cg->decReferenceCount(child);
 
@@ -1635,29 +1635,29 @@ static TR::Register *mstoreiToArrayHelper(TR::Node *node, TR::CodeGenerator *cg,
         // Int64: Cannot encode "movi vN.2d, #1"
         TR::Register *tmpGPR = cg->allocateRegister(TR_GPR);
         loadConstant64(cg, node, 1, tmpGPR);
-        generateTrg1Src1Instruction(cg, OP::vdup2d, node, tmpVRF, tmpGPR);
+        Inst_Trg1Src1(cg, OP::vdup2d, node, tmpVRF, tmpGPR);
         cg->stopUsingRegister(tmpGPR);
     } else {
-        generateTrg1ImmInstruction(cg, moviOp, node, tmpVRF, 1);
+        Inst_Trg1Imm(cg, moviOp, node, tmpVRF, 1);
     }
-    generateTrg1Src2Instruction(cg, OP::vand16b, node, tmpVRF, storeValReg, tmpVRF);
+    Inst_Trg1Src2(cg, OP::vand16b, node, tmpVRF, storeValReg, tmpVRF);
 
     // pack doubleword-length elements into word-length elements (for Long/DoubleVector mask store)
     if (numElements == 2)
-        generateTrg1Src1Instruction(cg, OP::vxtn_2s, node, tmpVRF, tmpVRF);
+        Inst_Trg1Src1(cg, OP::vxtn_2s, node, tmpVRF, tmpVRF);
 
     // pack word-length elements into halfword-length elements (for Int/Float and Long/DoubleVector mask store)
     if (numElements <= 4)
-        generateTrg1Src1Instruction(cg, OP::vxtn_4h, node, tmpVRF, tmpVRF);
+        Inst_Trg1Src1(cg, OP::vxtn_4h, node, tmpVRF, tmpVRF);
 
     // pack halfword-length elements into byte-length elements (for Short, Int/Float, and Long/DoubleVector mask store)
     if (numElements <= 8)
-        generateTrg1Src1Instruction(cg, OP::vxtn_8b, node, tmpVRF, tmpVRF);
+        Inst_Trg1Src1(cg, OP::vxtn_8b, node, tmpVRF, tmpVRF);
 
     TR::MemoryReference *tempMR = MRef_node(cg, node);
     tempMR->validateImmediateOffsetAlignment(node, numElements, cg);
 
-    generateMemSrc1Instruction(cg, storeOp, node, tempMR, tmpVRF);
+    Inst_MemSrc1(cg, storeOp, node, tempMR, tmpVRF);
 
     cg->stopUsingRegister(tmpVRF);
     cg->decReferenceCount(storeValNode);
@@ -1801,8 +1801,8 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
         maskReg = cg->allocateRegister(TR_VRF);
         if (op != TR::v2m) {
             /* Clear maskReg, then insert the mask value in GPR to the first element of maskReg. */
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, maskReg, 0);
-            generateMovGPRToVectorElementInstruction(cg, copyToGPRInstOp, node, maskReg, firstReg, 0);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, maskReg, 0);
+            Inst_MovGPRToVectorElement(cg, copyToGPRInstOp, node, maskReg, firstReg, 0);
         }
     }
 
@@ -1812,8 +1812,8 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
          * This makes the first element to be in lower 64bit and the second element to be in upper 64bit.
          * Then, use cmeq to compare each 64bit element with 0.
          */
-        generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 9);
-        generateTrg1Src1Instruction(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
+        Inst_Trg1Src2Imm(cg, OP::vext16b, node, maskReg, maskReg, maskReg, 9);
+        Inst_Trg1Src1(cg, OP::vcmeq2d_zero, node, maskReg, maskReg);
     } else if (op == TR::i2m) {
         /*
          * Use unsigned extend long instruction to convert 8bit elements to 16bit elements,
@@ -1821,20 +1821,20 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
          * It is guaranteed that the msb of each 32bit element is not set, so we can safely
          * use cmgt_zero to check if the mask is set.
          */
-        generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-        generateVectorUXTLInstruction(cg, TR::Int16, node, maskReg, maskReg, false);
-        generateTrg1Src1Instruction(cg, OP::vcmgt4s_zero, node, maskReg, maskReg);
+        Inst_VectorUXTL(cg, TR::Int8, node, maskReg, maskReg, false);
+        Inst_VectorUXTL(cg, TR::Int16, node, maskReg, maskReg, false);
+        Inst_Trg1Src1(cg, OP::vcmgt4s_zero, node, maskReg, maskReg);
     } else if (op == TR::l2m) {
         /*
          * Use unsigned extend long instruction to convert 8bit elements to 16bit elements.
          * It is guaranteed that the msb of each 16bit element is not set, so we can safely
          * use cmgt_zero to check if the mask is set.
          */
-        generateVectorUXTLInstruction(cg, TR::Int8, node, maskReg, maskReg, false);
-        generateTrg1Src1Instruction(cg, OP::vcmgt8h_zero, node, maskReg, maskReg);
+        Inst_VectorUXTL(cg, TR::Int8, node, maskReg, maskReg, false);
+        Inst_Trg1Src1(cg, OP::vcmgt8h_zero, node, maskReg, maskReg);
     } else /* op == TR::v2m */
     {
-        generateTrg1Src1Instruction(cg, OP::vcmeq16b_zero, node, maskReg, firstReg);
+        Inst_Trg1Src1(cg, OP::vcmeq16b_zero, node, maskReg, firstReg);
     }
 
     if ((op == TR::s2m) || (op == TR::v2m)) {
@@ -1842,7 +1842,7 @@ TR::Register *toMaskConversionHelper(TR::Node *node, bool omitNot, TR::CodeGener
             TR::Compilation *comp = cg->comp();
             logprintf(comp->getOption(TR_TraceCG), comp->log(), "omitting vnot instruction at node %p\n", node);
         } else {
-            generateTrg1Src1Instruction(cg, OP::vnot16b, node, maskReg, maskReg);
+            Inst_Trg1Src1(cg, OP::vnot16b, node, maskReg, maskReg);
         }
     }
 
@@ -1895,9 +1895,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2sEvaluator(TR::Node *node, TR::CodeGe
      * Use vector extract to move the 7th and 8th element to the 1st and 2nd element position respectively.
      * Then, perform unsigned shift right by 7bit to get boolean results.
      */
-    generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
-    generateVectorShiftImmediateInstruction(cg, OP::vushr16b, node, tempReg, tempReg, 7);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovwh, node, resReg, tempReg, 0);
+    Inst_Trg1Src2Imm(cg, OP::vext16b, node, tempReg, maskReg, maskReg, 7);
+    Inst_VectorShiftImmediate(cg, OP::vushr16b, node, tempReg, tempReg, 7);
+    Inst_MovVectorElementToGPR(cg, OP::umovwh, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1914,10 +1914,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2iEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *resReg = cg->allocateRegister(TR_GPR);
-    generateTrg1Src1Instruction(cg, OP::vxtn_4h, node, tempReg, maskReg);
-    generateTrg1Src1Instruction(cg, OP::vxtn_8b, node, tempReg, tempReg);
-    generateTrg1Src1Instruction(cg, OP::vneg16b, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovws, node, resReg, tempReg, 0);
+    Inst_Trg1Src1(cg, OP::vxtn_4h, node, tempReg, maskReg);
+    Inst_Trg1Src1(cg, OP::vxtn_8b, node, tempReg, tempReg);
+    Inst_Trg1Src1(cg, OP::vneg16b, node, tempReg, tempReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovws, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1934,9 +1934,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2lEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *tempReg = cg->allocateRegister(TR_VRF);
     TR::Register *resReg = cg->allocateRegister(TR_GPR);
-    generateTrg1Src1Instruction(cg, OP::vxtn_8b, node, tempReg, maskReg);
-    generateTrg1Src1Instruction(cg, OP::vneg16b, node, tempReg, tempReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, tempReg, 0);
+    Inst_Trg1Src1(cg, OP::vxtn_8b, node, tempReg, maskReg);
+    Inst_Trg1Src1(cg, OP::vneg16b, node, tempReg, tempReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, tempReg, 0);
 
     node->setRegister(resReg);
     cg->stopUsingRegister(tempReg);
@@ -1952,7 +1952,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::m2vEvaluator(TR::Node *node, TR::CodeGe
 
     TR::Register *maskReg = cg->evaluate(firstChild);
     TR::Register *resReg = cg->allocateRegister(TR_VRF);
-    generateTrg1Src1Instruction(cg, OP::vneg16b, node, resReg, maskReg);
+    Inst_Trg1Src1(cg, OP::vneg16b, node, resReg, maskReg);
 
     node->setRegister(resReg);
     cg->decReferenceCount(firstChild);
@@ -1967,7 +1967,7 @@ TR::Instruction *OMR::ARM64::TreeEvaluator::vsplatsImmediateHelper(TR::Node *nod
         auto constValue = firstChild->getConstValue();
         switch (elementType) {
             case TR::Int8:
-                return generateTrg1ImmInstruction(cg, OP::vmovi16b, node, treg, constValue & 0xff);
+                return Inst_Trg1Imm(cg, OP::vmovi16b, node, treg, constValue & 0xff);
 
             case TR::Int16: {
                 uint16_t value = static_cast<uint16_t>(constValue & 0xffff);
@@ -2063,7 +2063,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
                 return NULL;
         }
 
-        generateTrg1Src1Instruction(cg, op, node, resReg, srcReg);
+        Inst_Trg1Src1(cg, op, node, resReg, srcReg);
     }
 
     cg->decReferenceCount(firstChild);
@@ -2100,9 +2100,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::vfmaEvaluator(TR::Node *node, TR::CodeG
         targetReg = thirdReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
+        Inst_Trg1Src2(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
     }
-    generateTrg1Src2Instruction(cg, op, node, targetReg, firstReg, secondReg);
+    Inst_Trg1Src2(cg, op, node, targetReg, firstReg, secondReg);
     node->setRegister(targetReg);
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -2242,16 +2242,16 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
         && (secondChild->getFirstChild()->isConstZeroValue())) {
         recursivelyDecRefCountOnSecondChild = true;
         op = vectorCompareZeroOpCodes[compareOp - 1][elemType - 1];
-        generateTrg1Src1Instruction(cg, op, node, targetReg, firstReg);
+        Inst_Trg1Src1(cg, op, node, targetReg, firstReg);
     } else {
         TR::Register *secondReg = cg->evaluate(secondChild);
         recursivelyDecRefCountOnSecondChild = false;
         op = vectorCompareOpCodes[compareOp - 1][elemType - 1];
         if ((compareOp == VECTOR_COMPARE_LT) || (compareOp == VECTOR_COMPARE_LE)) {
             /* Flip lhs and rhs for those compare operation since aarch64 does not have vector compare lt nor le. */
-            generateTrg1Src2Instruction(cg, op, node, targetReg, secondReg, firstReg);
+            Inst_Trg1Src2(cg, op, node, targetReg, secondReg, firstReg);
         } else {
-            generateTrg1Src2Instruction(cg, op, node, targetReg, firstReg, secondReg);
+            Inst_Trg1Src2(cg, op, node, targetReg, firstReg, secondReg);
         }
     }
 
@@ -2264,14 +2264,14 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
         if (notAfterCompare) {
             if (flipMask) {
                 /* (not a) and (not b) = not (a or b) */
-                generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, targetReg, maskReg);
+                Inst_Trg1Src2(cg, OP::vorr16b, node, targetReg, targetReg, maskReg);
             } else {
                 /* a and (not b) = not ((not a) and b) */
-                generateTrg1Src2Instruction(cg, OP::vbic16b, node, targetReg, maskReg, targetReg);
+                Inst_Trg1Src2(cg, OP::vbic16b, node, targetReg, maskReg, targetReg);
                 notAfterCompare = false;
             }
         } else {
-            generateTrg1Src2Instruction(cg, flipMask ? OP::vbic16b : OP::vand16b, node, targetReg, targetReg, maskReg);
+            Inst_Trg1Src2(cg, flipMask ? OP::vbic16b : OP::vand16b, node, targetReg, targetReg, maskReg);
         }
 
         cg->decReferenceCount(thirdChild);
@@ -2283,7 +2283,7 @@ static TR::Register *vcmpHelper(TR::Node *node, VectorCompareOps compareOp, bool
      */
     if (!omitNot) {
         if (notAfterCompare) {
-            generateTrg1Src1Instruction(cg, OP::vnot16b, node, targetReg, targetReg);
+            Inst_Trg1Src1(cg, OP::vnot16b, node, targetReg, targetReg);
         }
     } else {
         if (notAfterCompare) {
@@ -2394,11 +2394,11 @@ static TR::Register *inlineVectorReductionOp(TR::Node *node, TR::CodeGenerator *
                     TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
                     break;
             }
-            generateTrg1Src1Instruction(cg, op, node, tmpReg, sourceReg);
-            generateMovVectorElementToGPRInstruction(cg, movOp, node, resReg, tmpReg, 0);
+            Inst_Trg1Src1(cg, op, node, tmpReg, sourceReg);
+            Inst_MovVectorElementToGPR(cg, movOp, node, resReg, tmpReg, 0);
             cg->stopUsingRegister(tmpReg);
         } else {
-            generateTrg1Src1Instruction(cg, op, node, resReg, sourceReg);
+            Inst_Trg1Src1(cg, op, node, resReg, sourceReg);
         }
     }
 
@@ -2422,11 +2422,11 @@ static TR::Register *vreductionAddFloatHelper(TR::Node *node, TR::DataType et, T
 {
     if (et == TR::Float) {
         TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, OP::vfaddp4s, node, tmpReg, srcReg, srcReg);
-        generateTrg1Src1Instruction(cg, OP::faddp2s, node, resReg, tmpReg);
+        Inst_Trg1Src2(cg, OP::vfaddp4s, node, tmpReg, srcReg, srcReg);
+        Inst_Trg1Src1(cg, OP::faddp2s, node, resReg, tmpReg);
         cg->stopUsingRegister(tmpReg);
     } else if (et == TR::Double) {
-        generateTrg1Src1Instruction(cg, OP::faddp2d, node, resReg, srcReg);
+        Inst_Trg1Src1(cg, OP::faddp2d, node, resReg, srcReg);
     } else {
         TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
     }
@@ -2509,26 +2509,26 @@ static TR::Register *vreductionHelper(TR::Node *node, TR::DataType et, OP::Mnemo
     /*
      * Generating an ext instruction to split elements into 2 vector registers and perform a lanewise operation.
      */
-    generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, srcReg, srcReg, 8);
-    generateTrg1Src2Instruction(cg, op, node, tmp0Reg, srcReg, tmp1Reg);
+    Inst_Trg1Src2Imm(cg, OP::vext16b, node, tmp1Reg, srcReg, srcReg, 8);
+    Inst_Trg1Src2(cg, op, node, tmp0Reg, srcReg, tmp1Reg);
 
     if ((et != TR::Int64) && (et != TR::Double)) {
-        generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 4);
-        generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
+        Inst_Trg1Src2Imm(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 4);
+        Inst_Trg1Src2(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
 
         if ((et != TR::Int32) && (et != TR::Float)) {
-            generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 2);
-            generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
+            Inst_Trg1Src2Imm(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 2);
+            Inst_Trg1Src2(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
 
             if (et == TR::Int8) {
-                generateTrg1Src2ImmInstruction(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 1);
-                generateTrg1Src2Instruction(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
+                Inst_Trg1Src2Imm(cg, OP::vext16b, node, tmp1Reg, tmp0Reg, tmp0Reg, 1);
+                Inst_Trg1Src2(cg, op, node, tmp0Reg, tmp0Reg, tmp1Reg);
             }
         }
     }
 
     if (useGPRForResult) {
-        generateMovVectorElementToGPRInstruction(cg, movOp, node, resReg, tmp0Reg, 0);
+        Inst_MovVectorElementToGPR(cg, movOp, node, resReg, tmp0Reg, 0);
         cg->stopUsingRegister(tmp0Reg);
     }
 
@@ -2598,11 +2598,11 @@ static TR::Register *vreductionMinMaxInt64Helper(TR::Node *node, bool isMax, TR:
 {
     TR::Register *tmpReg = cg->allocateRegister(TR_GPR);
 
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, tmpReg, srcReg, 0);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, srcReg, 1);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, tmpReg, srcReg, 0);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, srcReg, 1);
 
-    generateCompareInstruction(cg, node, tmpReg, resReg, true);
-    generateCondTrg1Src2Instruction(cg, OP::cselx, node, resReg, tmpReg, resReg, isMax ? TR::CC_GT : TR::CC_LT);
+    Inst_Compare(cg, node, tmpReg, resReg, true);
+    Inst_CondTrg1Src2(cg, OP::cselx, node, resReg, tmpReg, resReg, isMax ? TR::CC_GT : TR::CC_LT);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -2730,9 +2730,9 @@ static TR::Register *vreductionMulInt64Helper(TR::Node *node, TR::Register *resR
 {
     TR::Register *tmp0Reg = cg->allocateRegister(TR_GPR);
 
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, tmp0Reg, srcReg, 0);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovxd, node, resReg, srcReg, 1);
-    generateMulInstruction(cg, node, resReg, tmp0Reg, resReg, true);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, tmp0Reg, srcReg, 0);
+    Inst_MovVectorElementToGPR(cg, OP::umovxd, node, resReg, srcReg, 1);
+    Inst_Mul(cg, node, resReg, tmp0Reg, resReg, true);
 
     cg->stopUsingRegister(tmp0Reg);
 
@@ -2757,11 +2757,11 @@ static TR::Register *vreductionMulFloatingPointHelper(TR::Node *node, TR::DataTy
     TR::Register *srcReg, TR::CodeGenerator *cg)
 {
     if (et == TR::Float) {
-        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, srcReg, srcReg, 1);
-        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 2);
-        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 3);
+        Inst_Trg1Src2IndexedElement(cg, OP::fmulelem_4s, node, resReg, srcReg, srcReg, 1);
+        Inst_Trg1Src2IndexedElement(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 2);
+        Inst_Trg1Src2IndexedElement(cg, OP::fmulelem_4s, node, resReg, resReg, srcReg, 3);
     } else {
-        generateTrg1Src2IndexedElementInstruction(cg, OP::fmulelem_2d, node, resReg, srcReg, srcReg, 1);
+        Inst_Trg1Src2IndexedElement(cg, OP::fmulelem_2d, node, resReg, srcReg, srcReg, 1);
     }
 
     return resReg;
@@ -2941,14 +2941,14 @@ static TR::Register *vbitselectHelper(TR::Node *node, TR::CodeGenerator *cg, boo
         targetReg = maskReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, maskReg, maskReg);
+        Inst_Trg1Src2(cg, OP::vorr16b, node, targetReg, maskReg, maskReg);
     }
 
     /*
      * vbitselect helper extracts bits from the "false" operand if the corresponding bit of the "mask" operand is 0,
      * otherwise from the "true" operand.
      */
-    generateTrg1Src2Instruction(cg, OP::vbsl16b, node, targetReg, trueReg, falseReg);
+    Inst_Trg1Src2(cg, OP::vbsl16b, node, targetReg, trueReg, falseReg);
     node->setRegister(targetReg);
     cg->decReferenceCount(falseChild);
     cg->decReferenceCount(trueChild);
@@ -3019,7 +3019,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *no
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, lhsReg, rhsReg, cg);
     } else {
-        generateTrg1Src2Instruction(cg, op, node, resReg, lhsReg, rhsReg);
+        Inst_Trg1Src2(cg, op, node, resReg, lhsReg, rhsReg);
     }
 
     bool flipMask = false;
@@ -3029,7 +3029,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedBinaryOp(TR::Node *no
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, lhsReg, maskReg);
+    Inst_Trg1Src2(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, lhsReg, maskReg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -3055,7 +3055,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedUnaryOp(TR::Node *nod
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, srcReg, cg);
     } else {
-        generateTrg1Src1Instruction(cg, op, node, resReg, srcReg);
+        Inst_Trg1Src1(cg, op, node, resReg, srcReg);
     }
 
     bool flipMask = false;
@@ -3065,7 +3065,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorMaskedUnaryOp(TR::Node *nod
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, srcReg, maskReg);
+    Inst_Trg1Src2(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, resReg, srcReg, maskReg);
 
     cg->decReferenceCount(firstChild);
     cg->decReferenceCount(secondChild);
@@ -3244,9 +3244,9 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmfmaEvaluator(TR::Node *node, TR::Code
         targetReg = thirdReg;
     } else {
         targetReg = cg->allocateRegister(TR_VRF);
-        generateTrg1Src2Instruction(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
+        Inst_Trg1Src2(cg, OP::vorr16b, node, targetReg, thirdReg, thirdReg);
     }
-    generateTrg1Src2Instruction(cg, op, node, targetReg, firstReg, secondReg);
+    Inst_Trg1Src2(cg, op, node, targetReg, firstReg, secondReg);
 
     bool flipMask = false;
     TR::Register *maskReg = evaluateMaskNode(fourthChild, flipMask, cg);
@@ -3255,7 +3255,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmfmaEvaluator(TR::Node *node, TR::Code
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, firstReg, maskReg);
+    Inst_Trg1Src2(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, firstReg, maskReg);
 
     node->setRegister(targetReg);
     cg->decReferenceCount(firstChild);
@@ -3486,7 +3486,7 @@ static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGener
      * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
      * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
      */
-    generateTrg1Src2Instruction(cg, flipMask ? OP::vbif16b : OP::vbit16b, node, tmpReg, sourceReg, maskReg);
+    Inst_Trg1Src2(cg, flipMask ? OP::vbif16b : OP::vbit16b, node, tmpReg, sourceReg, maskReg);
 
     TR::Register *resReg = et.isIntegral() ? cg->allocateRegister(TR_GPR) : cg->allocateRegister(TR_VRF);
 
@@ -3515,10 +3515,10 @@ static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGener
                     TR_ASSERT_FATAL_WITH_NODE(node, false, "Unexpected element type");
                     break;
             }
-            generateTrg1Src1Instruction(cg, op, node, tmpReg, tmpReg);
-            generateMovVectorElementToGPRInstruction(cg, movOp, node, resReg, tmpReg, 0);
+            Inst_Trg1Src1(cg, op, node, tmpReg, tmpReg);
+            Inst_MovVectorElementToGPR(cg, movOp, node, resReg, tmpReg, 0);
         } else {
-            generateTrg1Src1Instruction(cg, op, node, resReg, tmpReg);
+            Inst_Trg1Src1(cg, op, node, resReg, tmpReg);
         }
     }
 
@@ -3538,7 +3538,7 @@ static TR::Register *inlineVectorMaskedReductionOp(TR::Node *node, TR::CodeGener
  */
 static void loadZeroVector(TR::Node *node, TR::DataType et, TR::Register *identityReg, TR::CodeGenerator *cg)
 {
-    generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0);
+    Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 0);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3585,7 +3585,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAddEvaluator(TR::Node *node,
 static void loadIdentityVectorForReductionAnd(TR::Node *node, TR::DataType et, TR::Register *identityReg,
     TR::CodeGenerator *cg)
 {
-    generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0xff);
+    Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 0xff);
 }
 
 TR::Register *OMR::ARM64::TreeEvaluator::vmreductionAndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3631,30 +3631,28 @@ static void loadIdentityVectorForReductionMax(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0x80);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 0x80);
             break;
         case TR::Int16:
-            generateTrg1ImmShiftedInstruction(cg, OP::vmovi8h, node, identityReg, 0x80, 8);
+            Inst_Trg1ImmShifted(cg, OP::vmovi8h, node, identityReg, 0x80, 8);
             break;
         case TR::Int32:
-            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0x80, 24);
+            Inst_Trg1ImmShifted(cg, OP::vmovi4s, node, identityReg, 0x80, 24);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
-                0x80); /* Loads 0xff000000_00000000 into each element */
-            generateTrg1ImmShiftedInstruction(cg, OP::vbicimm4s, node, identityReg, 0x7f,
+            Inst_Trg1Imm(cg, OP::vmovi2d, node, identityReg, 0x80); /* Loads 0xff000000_00000000 into each element */
+            Inst_Trg1ImmShifted(cg, OP::vbicimm4s, node, identityReg, 0x7f,
                 24); /* Clear unneeded bits. We do not have bic for 64bit integer, but vbicimm4s works for this case. */
             break;
         case TR::Float:
             /* Negative Infinity */
-            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0xff, 24);
-            generateTrg1ImmShiftedInstruction(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
+            Inst_Trg1ImmShifted(cg, OP::vmovi4s, node, identityReg, 0xff, 24);
+            Inst_Trg1ImmShifted(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
             break;
         case TR::Double:
             /* Negative Infinity */
-            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
-                0x80); /* Loads 0xff000000_00000000 into each element */
-            generateVectorShiftImmediateInstruction(cg, OP::vsshr2d, node, identityReg, identityReg,
+            Inst_Trg1Imm(cg, OP::vmovi2d, node, identityReg, 0x80); /* Loads 0xff000000_00000000 into each element */
+            Inst_VectorShiftImmediate(cg, OP::vsshr2d, node, identityReg, identityReg,
                 4); /* Do signed shift right by 4bits to get 0xfff00000_00000000 */
             break;
         default:
@@ -3710,30 +3708,29 @@ static void loadIdentityVectorForReductionMin(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0x7f);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 0x7f);
             break;
         case TR::Int16:
-            generateTrg1ImmShiftedInstruction(cg, OP::vmvni8h, node, identityReg, 0x80, 8);
+            Inst_Trg1ImmShifted(cg, OP::vmvni8h, node, identityReg, 0x80, 8);
             break;
         case TR::Int32:
-            generateTrg1ImmShiftedInstruction(cg, OP::vmvni4s, node, identityReg, 0x80, 24);
+            Inst_Trg1ImmShifted(cg, OP::vmvni4s, node, identityReg, 0x80, 24);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 0xff);
-            generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, identityReg, identityReg, 1);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 0xff);
+            Inst_VectorShiftImmediate(cg, OP::vushr2d, node, identityReg, identityReg, 1);
             break;
         case TR::Float:
             /* Positive Infinity */
-            generateTrg1ImmShiftedInstruction(cg, OP::vmovi4s, node, identityReg, 0x7f, 24);
-            generateTrg1ImmShiftedInstruction(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
+            Inst_Trg1ImmShifted(cg, OP::vmovi4s, node, identityReg, 0x7f, 24);
+            Inst_Trg1ImmShifted(cg, OP::vorrimm4s, node, identityReg, 0x80, 16);
             break;
         case TR::Double:
             /* Positive Infinity */
-            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
-                0x80); /* Loads 0xff000000_00000000 into each element */
-            generateVectorShiftImmediateInstruction(cg, OP::vsshr2d, node, identityReg, identityReg,
+            Inst_Trg1Imm(cg, OP::vmovi2d, node, identityReg, 0x80); /* Loads 0xff000000_00000000 into each element */
+            Inst_VectorShiftImmediate(cg, OP::vsshr2d, node, identityReg, identityReg,
                 4); /* Do signed shift right by 4bits to get 0xfff00000_00000000 */
-            generateTrg1ImmShiftedInstruction(cg, OP::vbicimm4s, node, identityReg, 0x80,
+            Inst_Trg1ImmShifted(cg, OP::vbicimm4s, node, identityReg, 0x80,
                 24); /* Clear sign bit. We do not have bic for 64bit integer, but vbicimm4s works for this case. */
             break;
         default:
@@ -3792,27 +3789,25 @@ static void loadIdentityVectorForReductionMul(TR::Node *node, TR::DataType et, T
 {
     switch (et) {
         case TR::Int8:
-            generateTrg1ImmInstruction(cg, OP::vmovi16b, node, identityReg, 1);
+            Inst_Trg1Imm(cg, OP::vmovi16b, node, identityReg, 1);
             break;
         case TR::Int16:
-            generateTrg1ImmInstruction(cg, OP::vmovi8h, node, identityReg, 1);
+            Inst_Trg1Imm(cg, OP::vmovi8h, node, identityReg, 1);
             break;
         case TR::Int32:
-            generateTrg1ImmInstruction(cg, OP::vmovi4s, node, identityReg, 1);
+            Inst_Trg1Imm(cg, OP::vmovi4s, node, identityReg, 1);
             break;
         case TR::Int64:
-            generateTrg1ImmInstruction(cg, OP::vmovi2d, node, identityReg,
-                1); /* Loads 0x00000000_000000ff into each element */
-            generateTrg1ImmInstruction(cg, OP::vbicimm4s, node, identityReg,
+            Inst_Trg1Imm(cg, OP::vmovi2d, node, identityReg, 1); /* Loads 0x00000000_000000ff into each element */
+            Inst_Trg1Imm(cg, OP::vbicimm4s, node, identityReg,
                 0xfe); /* Clear unneeded bits. We do not have bic for 64bit integer, but vbicimm4s works for this case.
                         */
             break;
         case TR::Float:
-            generateTrg1ImmInstruction(cg, OP::vfmov4s, node, identityReg,
-                0x70); /* Loads 0x3f800000 (1.0f) into each element */
+            Inst_Trg1Imm(cg, OP::vfmov4s, node, identityReg, 0x70); /* Loads 0x3f800000 (1.0f) into each element */
             break;
         case TR::Double:
-            generateTrg1ImmInstruction(cg, OP::vfmov2d, node, identityReg,
+            Inst_Trg1Imm(cg, OP::vfmov2d, node, identityReg,
                 0x70); /* Loads 0x3ff00000_00000000 (1.0) into each element */
             break;
         default:
@@ -3977,12 +3972,12 @@ static TR::Register *vpopcntEvaluatorHelper(TR::Node *node, TR::Register *result
 {
     TR::DataType et = node->getDataType().getVectorElementType();
 
-    generateTrg1Src1Instruction(cg, OP::vcnt16b, node, resultReg, srcReg);
-    generateTrg1Src1Instruction(cg, OP::vuaddlp16b, node, resultReg, resultReg);
+    Inst_Trg1Src1(cg, OP::vcnt16b, node, resultReg, srcReg);
+    Inst_Trg1Src1(cg, OP::vuaddlp16b, node, resultReg, resultReg);
     if (et != TR::Int16) {
-        generateTrg1Src1Instruction(cg, OP::vuaddlp8h, node, resultReg, resultReg);
+        Inst_Trg1Src1(cg, OP::vuaddlp8h, node, resultReg, resultReg);
         if (et == TR::Int64) {
-            generateTrg1Src1Instruction(cg, OP::vuaddlp4s, node, resultReg, resultReg);
+            Inst_Trg1Src1(cg, OP::vuaddlp4s, node, resultReg, resultReg);
         }
     }
     return resultReg;
@@ -4081,7 +4076,7 @@ static TR::Register *vectorShiftImmediateHelper(TR::Node *node, TR::CodeGenerato
                                                             : isLogicalRightShift ? OP::vushr16b
                                                                                   : OP::vsshr16b)
             + (elementType - TR::Int8));
-        generateVectorShiftImmediateInstruction(cg, op, node, targetReg, lhsReg, value);
+        Inst_VectorShiftImmediate(cg, op, node, targetReg, lhsReg, value);
         if (isVectorMaskedShift) {
             bool flipMask = false;
             TR::Register *maskReg = evaluateMaskNode(thirdChild, flipMask, cg);
@@ -4089,7 +4084,7 @@ static TR::Register *vectorShiftImmediateHelper(TR::Node *node, TR::CodeGenerato
              * BIT inserts each bit from the first source if the corresponding bit of the second source is 1.
              * BIF inserts each bit from the first source if the corresponding bit of the second source is 0.
              */
-            generateTrg1Src2Instruction(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, lhsReg, maskReg);
+            Inst_Trg1Src2(cg, flipMask ? OP::vbit16b : OP::vbif16b, node, targetReg, lhsReg, maskReg);
 
             cg->decReferenceCount(thirdChild);
         }
@@ -4190,8 +4185,8 @@ static TR::Register *vectorRightShiftHelper(TR::Node *node, TR::Register *result
     OP::Mnemonic negOp = static_cast<OP::Mnemonic>(OP::vneg16b + (elementType - TR::Int8));
     OP::Mnemonic shiftOp
         = static_cast<OP::Mnemonic>((isLogicalShift ? OP::vushl16b : OP::vsshl16b) + (elementType - TR::Int8));
-    generateTrg1Src1Instruction(cg, negOp, node, resultReg, rhsReg);
-    generateTrg1Src2Instruction(cg, shiftOp, node, resultReg, lhsReg, resultReg);
+    Inst_Trg1Src1(cg, negOp, node, resultReg, rhsReg);
+    Inst_Trg1Src2(cg, shiftOp, node, resultReg, lhsReg, resultReg);
 
     return resultReg;
 }
@@ -4278,13 +4273,13 @@ static TR::Register *vectorRotateHelper(TR::Node *node, TR::Register *resultReg,
          * integer elements. Loading the value to a vector of 32-bit integer elements and using UXTL to extend elements
          * to 64-bit.
          */
-        generateTrg1ImmInstruction(cg, OP::vmovi4s, node, tempReg, 64);
-        generateVectorUXTLInstruction(cg, TR::Int32, node, tempReg, tempReg, false);
+        Inst_Trg1Imm(cg, OP::vmovi4s, node, tempReg, 64);
+        Inst_VectorUXTL(cg, TR::Int32, node, tempReg, tempReg, false);
     } else {
         const int32_t sizeInBits = TR::DataType::getSize(elementType) * 8;
         OP::Mnemonic movOp
             = (elementType == TR::Int8) ? OP::vmovi16b : ((elementType == TR::Int16) ? OP::vmovi8h : OP::vmovi4s);
-        generateTrg1ImmInstruction(cg, movOp, node, tempReg, sizeInBits);
+        Inst_Trg1Imm(cg, movOp, node, tempReg, sizeInBits);
     }
 
     /*
@@ -4296,13 +4291,13 @@ static TR::Register *vectorRotateHelper(TR::Node *node, TR::Register *resultReg,
      * ushl      tempReg, lhsReg, temp2Reg
      * orr       resultReg, resultReg, tempReg ; (lhs << leftShitAmount) || (lhs >>> (sizeInBits - leftShitAmount))
      */
-    generateTrg1Src1Instruction(cg, cmpOp, node, temp2Reg, rhsReg);
-    generateTrg1Src2Instruction(cg, addOp, node, temp3Reg, rhsReg, tempReg);
-    generateTrg1Src2Instruction(cg, OP::vbif16b, node, temp3Reg, rhsReg, temp2Reg);
-    generateTrg1Src2Instruction(cg, subOp, node, temp2Reg, temp3Reg, tempReg);
-    generateTrg1Src2Instruction(cg, shiftOp, node, resultReg, lhsReg, temp3Reg);
-    generateTrg1Src2Instruction(cg, shiftOp, node, tempReg, lhsReg, temp2Reg);
-    generateTrg1Src2Instruction(cg, OP::vorr16b, node, resultReg, resultReg, tempReg);
+    Inst_Trg1Src1(cg, cmpOp, node, temp2Reg, rhsReg);
+    Inst_Trg1Src2(cg, addOp, node, temp3Reg, rhsReg, tempReg);
+    Inst_Trg1Src2(cg, OP::vbif16b, node, temp3Reg, rhsReg, temp2Reg);
+    Inst_Trg1Src2(cg, subOp, node, temp2Reg, temp3Reg, tempReg);
+    Inst_Trg1Src2(cg, shiftOp, node, resultReg, lhsReg, temp3Reg);
+    Inst_Trg1Src2(cg, shiftOp, node, tempReg, lhsReg, temp2Reg);
+    Inst_Trg1Src2(cg, OP::vorr16b, node, resultReg, resultReg, tempReg);
 
     cg->stopUsingRegister(tempReg);
     cg->stopUsingRegister(temp2Reg);
@@ -4363,22 +4358,22 @@ static TR::Register *vectorLeadingOrTrailingZeroesHelper(TR::Node *node, TR::Reg
                                                               : OP::vrev64_16b;
         /* Reverses bit order in each element. */
         dataReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src1Instruction(cg, OP::vrbit16b, node, dataReg, srcReg);
+        Inst_Trg1Src1(cg, OP::vrbit16b, node, dataReg, srcReg);
         if (elementType != TR::Int8) {
-            generateTrg1Src1Instruction(cg, revOp, node, dataReg, dataReg);
+            Inst_Trg1Src1(cg, revOp, node, dataReg, dataReg);
         }
     }
     if (is64bit) {
         TR::Register *tempReg = srm->findOrCreateScratchRegister(TR_VRF);
-        generateTrg1Src1Instruction(cg, OP::vclz4s, node, resultReg, dataReg);
-        generateVectorShiftImmediateInstruction(cg, OP::vushr2d, node, tempReg, dataReg, 32);
-        generateTrg1Src1Instruction(cg, OP::vcmeq4s_zero, node, tempReg, tempReg);
+        Inst_Trg1Src1(cg, OP::vclz4s, node, resultReg, dataReg);
+        Inst_VectorShiftImmediate(cg, OP::vushr2d, node, tempReg, dataReg, 32);
+        Inst_Trg1Src1(cg, OP::vcmeq4s_zero, node, tempReg, tempReg);
         /* Clears lower 32-bit of each 64-bit element if upper 32-bit of the corresponding element in the original
          * vector is zero. */
-        generateTrg1Src2Instruction(cg, OP::vand16b, node, resultReg, resultReg, tempReg);
-        generateTrg1Src1Instruction(cg, OP::vuaddlp4s, node, resultReg, resultReg);
+        Inst_Trg1Src2(cg, OP::vand16b, node, resultReg, resultReg, tempReg);
+        Inst_Trg1Src1(cg, OP::vuaddlp4s, node, resultReg, resultReg);
     } else {
-        generateTrg1Src1Instruction(cg, clzOp, node, resultReg, dataReg);
+        Inst_Trg1Src1(cg, clzOp, node, resultReg, dataReg);
     }
     srm->stopUsingRegisters();
 
@@ -4479,8 +4474,8 @@ static TR::Register *vectorBitSwapHelper(TR::Node *node, TR::Register *resultReg
                                                           : OP::vrev64_16b;
 
     /* Reverses bit order in each element. */
-    generateTrg1Src1Instruction(cg, OP::vrbit16b, node, resultReg, srcReg);
-    generateTrg1Src1Instruction(cg, revOp, node, resultReg, resultReg);
+    Inst_Trg1Src1(cg, OP::vrbit16b, node, resultReg, srcReg);
+    Inst_Trg1Src1(cg, revOp, node, resultReg, resultReg);
 
     return resultReg;
 }
@@ -4834,7 +4829,7 @@ static TR::Instruction *compareIntsAndBranchForArrayCopyBNDCHK(TR::ARM64Conditio
         TR::Node *sub2Child = firstChild->getSecondChild();
         src1Reg = cg->evaluate(sub1Child);
         src2Reg = cg->evaluate(sub2Child);
-        generateCompareInstruction(cg, node, src1Reg, src2Reg); // 32-bit comparison
+        Inst_Compare(cg, node, src1Reg, src2Reg); // 32-bit comparison
         cg->decReferenceCount(sub1Child);
         cg->decReferenceCount(sub2Child);
     } else {
@@ -4844,22 +4839,22 @@ static TR::Instruction *compareIntsAndBranchForArrayCopyBNDCHK(TR::ARM64Conditio
         if (secondChild->getOpCode().isLoadConst()) {
             int64_t value = static_cast<int64_t>(secondChild->getInt());
             if (constantIsUnsignedImm12(value)) {
-                generateCompareImmInstruction(cg, node, src1Reg, value); // 32-bit comparison
+                Inst_CompareImm(cg, node, src1Reg, value); // 32-bit comparison
                 foundConst = true;
             } else if (constantIsUnsignedImm12(-value)) {
-                generateCompareImmInstruction(cg, node, src1Reg, value); // 32-bit comparison
+                Inst_CompareImm(cg, node, src1Reg, value); // 32-bit comparison
                 foundConst = true;
             }
         }
         if (!foundConst) {
             src2Reg = cg->evaluate(secondChild);
-            generateCompareInstruction(cg, node, src1Reg, src2Reg); // 32-bit comparison
+            Inst_Compare(cg, node, src1Reg, src2Reg); // 32-bit comparison
         }
     }
 
     TR_ASSERT_FATAL_WITH_NODE(node, sr, "Must provide an ArrayCopyBNDCHK symref");
     cg->addSnippet(new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, snippetLabel, sr));
-    TR::Instruction *instr = generateConditionalBranchInstruction(cg, node, snippetLabel, branchCond);
+    TR::Instruction *instr = Inst_ConditionalBranch(cg, node, snippetLabel, branchCond);
 
     cg->machine()->setLinkRegisterKilled(true);
     cg->decReferenceCount(firstChild);
@@ -4881,8 +4876,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node
         if (secondChild->getOpCode().isLoadConst()) {
             if (firstChild->getInt() < secondChild->getInt()) {
                 // Check will always fail, just jump to the exception handler
-                instr = generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)exceptionBNDCHK->getMethodAddress(),
-                    NULL, exceptionBNDCHK, NULL);
+                instr = Inst_ImmSym(cg, OP::bl, node, (uintptr_t)exceptionBNDCHK->getMethodAddress(), NULL,
+                    exceptionBNDCHK, NULL);
                 cg->machine()->setLinkRegisterKilled(true);
             } else {
                 // Check will always succeed, no need for an instruction
@@ -5221,7 +5216,7 @@ TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *n
             cg->getSnippetsToBePatchedOnClassUnload()->push_front(snippet);
         }
     }
-    return generateTrg1ImmSymInstruction(cg, OP::ldrx, node, targetRegister, 0, labelSym, cursor);
+    return Inst_Trg1ImmSym(cg, OP::ldrx, node, targetRegister, 0, labelSym, cursor);
 }
 
 bool shouldLoadNegatedConstant32(int32_t value)
@@ -5328,17 +5323,16 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
     }
 
     if (op != OP::bad) {
-        cursor = generateTrg1ImmInstruction(cg, op, node, trgReg, imm, cursor);
+        cursor = Inst_Trg1Imm(cg, op, node, trgReg, imm, cursor);
     } else {
         bool n;
         uint32_t immEncoded;
         if (logicImmediateHelper(static_cast<uint32_t>(value), false, n, immEncoded)) {
-            cursor = generateMovBitMaskInstruction(cg, node, trgReg, n, immEncoded, false, cursor);
+            cursor = Inst_MovBitMask(cg, node, trgReg, n, immEncoded, false, cursor);
         } else {
             // need two instructions
-            cursor = generateTrg1ImmInstruction(cg, OP::movzw, node, trgReg, (value & 0xFFFF), cursor);
-            cursor = generateTrg1ImmInstruction(cg, OP::movkw, node, trgReg, (((value >> 16) & 0xFFFF) | TR::MOV_LSL16),
-                cursor);
+            cursor = Inst_Trg1Imm(cg, OP::movzw, node, trgReg, (value & 0xFFFF), cursor);
+            cursor = Inst_Trg1Imm(cg, OP::movkw, node, trgReg, (((value >> 16) & 0xFFFF) | TR::MOV_LSL16), cursor);
         }
     }
 
@@ -5357,10 +5351,10 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
 
     if (value == 0LL) {
         // 0
-        cursor = generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0, cursor);
+        cursor = Inst_Trg1Imm(cg, OP::movzx, node, trgReg, 0, cursor);
     } else if (~value == 0LL) {
         // -1
-        cursor = generateTrg1ImmInstruction(cg, OP::movnx, node, trgReg, 0, cursor);
+        cursor = Inst_Trg1Imm(cg, OP::movnx, node, trgReg, 0, cursor);
     } else {
         uint16_t h[4];
         int32_t i;
@@ -5370,7 +5364,7 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
         bool n;
         uint32_t immEncoded;
         if ((numInstrAndUseMovz.first > 1) && logicImmediateHelper(value, true, n, immEncoded)) {
-            cursor = generateMovBitMaskInstruction(cg, node, trgReg, n, immEncoded, true, cursor);
+            cursor = Inst_MovBitMask(cg, node, trgReg, n, immEncoded, true, cursor);
         } else {
             TR::Instruction *start = cursor;
 
@@ -5397,7 +5391,7 @@ TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t v
                 }
 
                 if (op != OP::bad) {
-                    cursor = generateTrg1ImmInstruction(cg, op, node, trgReg, imm, cursor);
+                    cursor = Inst_Trg1Imm(cg, op, node, trgReg, imm, cursor);
                 } else {
                     // generate no instruction here
                 }
@@ -5416,11 +5410,11 @@ void addConstant64(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, 
     if (value == 0) {
         // Do nothing
     } else if (constantIsUnsignedImm12(value)) {
-        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, trgReg, srcReg, value);
+        Inst_Trg1Src1Imm(cg, OP::addimmx, node, trgReg, srcReg, value);
     } else {
         TR::Register *tempReg = cg->allocateRegister();
         loadConstant64(cg, node, value, tempReg);
-        generateTrg1Src2Instruction(cg, OP::addx, node, trgReg, srcReg, tempReg);
+        Inst_Trg1Src2(cg, OP::addx, node, trgReg, srcReg, tempReg);
         cg->stopUsingRegister(tempReg);
     }
 }
@@ -5430,11 +5424,11 @@ void addConstant32(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, 
     if (value == 0) {
         // Do nothing
     } else if (constantIsUnsignedImm12(value)) {
-        generateTrg1Src1ImmInstruction(cg, OP::addimmw, node, trgReg, srcReg, value);
+        Inst_Trg1Src1Imm(cg, OP::addimmw, node, trgReg, srcReg, value);
     } else {
         TR::Register *tempReg = cg->allocateRegister();
         loadConstant32(cg, node, value, tempReg);
-        generateTrg1Src2Instruction(cg, OP::addw, node, trgReg, srcReg, tempReg);
+        Inst_Trg1Src2(cg, OP::addw, node, trgReg, srcReg, tempReg);
         cg->stopUsingRegister(tempReg);
     }
 }
@@ -5550,12 +5544,10 @@ static TR::Instruction *loadAddressConstantRelocatable(TR::CodeGenerator *cg, TR
     if (cursor == NULL)
         cursor = cg->getAppendInstruction();
 
-    cursor = firstInstruction = generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, value & 0x0000ffff, cursor);
-    cursor
-        = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, ((value >> 16) & 0x0000ffff) | TR::MOV_LSL16, cursor);
-    cursor = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, ((value >> 32) & 0x0000ffff) | (TR::MOV_LSL16 * 2),
-        cursor);
-    cursor = generateTrg1ImmInstruction(cg, OP::movkx, node, trgReg, (value >> 48) | (TR::MOV_LSL16 * 3), cursor);
+    cursor = firstInstruction = Inst_Trg1Imm(cg, OP::movzx, node, trgReg, value & 0x0000ffff, cursor);
+    cursor = Inst_Trg1Imm(cg, OP::movkx, node, trgReg, ((value >> 16) & 0x0000ffff) | TR::MOV_LSL16, cursor);
+    cursor = Inst_Trg1Imm(cg, OP::movkx, node, trgReg, ((value >> 32) & 0x0000ffff) | (TR::MOV_LSL16 * 2), cursor);
+    cursor = Inst_Trg1Imm(cg, OP::movkx, node, trgReg, (value >> 48) | (TR::MOV_LSL16 * 3), cursor);
 
     addMetaDataForLoadAddressConstantFixed(cg, node, firstInstruction, typeAddress, value);
 
@@ -5623,10 +5615,10 @@ TR::Register *commonLoadEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size,
     TR::MemoryReference *tempMR = MRef_node(cg, node);
     tempMR->validateImmediateOffsetAlignment(node, size, cg);
 
-    generateTrg1MemInstruction(cg, op, node, targetReg, tempMR);
+    Inst_Trg1Mem(cg, op, node, targetReg, tempMR);
 
     if (needSync) {
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishld);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ishld);
     }
 
     tempMR->decNodeReferenceCounts(cg);
@@ -5664,7 +5656,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
     if (constRefLabel != NULL) {
         // Load from the const ref slot using ldr literal (ldrx), which has a range of +/- 1MB.
         // We may eventually need to handle farther slots for splitWarmAndColdBlocks, e.g. with adrp + ldrimmx.
-        generateTrg1ImmSymInstruction(cg, OP::ldrx, node, tempReg, 0, constRefLabel);
+        Inst_Trg1ImmSym(cg, OP::ldrx, node, tempReg, 0, constRefLabel);
         return tempReg;
     }
 
@@ -5683,7 +5675,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
     TR::MemoryReference *tempMR = MRef_node(cg, node);
     tempMR->validateImmediateOffsetAlignment(node, size, cg);
 
-    generateTrg1MemInstruction(cg, op, node, tempReg, tempMR);
+    Inst_Trg1Mem(cg, op, node, tempReg, tempMR);
 
     if (node->getSymbolReference() == comp->getSymRefTab()->findVftSymbolRef()) {
         TR::TreeEvaluator::generateVFTMaskInstruction(cg, node, tempReg);
@@ -5692,7 +5684,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
     TR::Symbol *sym = node->getSymbolReference()->getSymbol();
     bool needSync = cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease();
     if (needSync) {
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishld);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ishld);
     }
 
     tempMR->decNodeReferenceCounts(cg);
@@ -5743,7 +5735,7 @@ TR::Register *commonStoreEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size
     }
 
     if (cg->comp()->target().isSMP() && sym->isAtLeastOrStrongerThanAcquireRelease()) {
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ishst);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ishst);
     }
 
     TR::Node *valueChildRoot = NULL;
@@ -5783,14 +5775,14 @@ TR::Register *commonStoreEvaluator(TR::Node *node, OP::Mnemonic op, int32_t size
             && valueChild->isConstZeroValue() && (valueChild->getRegister() == NULL))) {
         TR::Register *zeroReg = cg->allocateRegister();
         zeroReg->setAssignZeroRegister();
-        generateMemSrc1Instruction(cg, op, node, tempMR, zeroReg);
+        Inst_MemSrc1(cg, op, node, tempMR, zeroReg);
         cg->stopUsingRegister(zeroReg);
     } else {
-        generateMemSrc1Instruction(cg, op, node, tempMR, cg->evaluate(valueChild));
+        Inst_MemSrc1(cg, op, node, tempMR, cg->evaluate(valueChild));
     }
 
     if (cg->comp()->target().isSMP() && sym->isVolatile()) {
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ish);
     }
 
     if (valueChildRoot != NULL) {
@@ -5825,8 +5817,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::Cod
                 TR::Register *tempReg = cg->allocateRegister();
                 deps->addPostCondition(tempMR->getBaseRegister(), TR::RealRegister::x0);
                 deps->addPostCondition(tempReg, TR::RealRegister::x1);
-                generateImmSymInstruction(cg, OP::bl, node,
-                    reinterpret_cast<uintptr_t>(patchGCRHelperRef->getMethodAddress()), deps, patchGCRHelperRef, NULL);
+                Inst_ImmSym(cg, OP::bl, node, reinterpret_cast<uintptr_t>(patchGCRHelperRef->getMethodAddress()), deps,
+                    patchGCRHelperRef, NULL);
 
                 cg->stopUsingRegister(tempReg);
                 cg->recursivelyDecReferenceCount(node->getFirstChild());
@@ -6012,7 +6004,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraytranslateEvaluator(TR::Node *node,
     // Array Translate helper call
     TR::SymbolReference *helperSym = cg->symRefTab()->findOrCreateRuntimeHelper(helper);
     uintptr_t addr = reinterpret_cast<uintptr_t>(helperSym->getMethodAddress());
-    generateImmSymInstruction(cg, OP::bl, node, addr, deps, helperSym, NULL);
+    Inst_ImmSym(cg, OP::bl, node, addr, deps, helperSym, NULL);
 
     for (uint32_t i = 0; i < node->getNumChildren(); i++)
         cg->decReferenceCount(node->getChild(i));
@@ -6067,86 +6059,82 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                 = (vsplatsImmediateHelper(node, cg, valueNode, valueNode->getDataType(), vectorValueReg)) == NULL;
             if (needToLoadValueRegToVectorReg) {
                 valueReg = isValueZero ? cg->allocateRegister() : cg->evaluate(valueNode);
-                generateTrg1Src1Instruction(cg, dupOpCode, node, vectorValueReg, valueReg);
+                Inst_Trg1Src1(cg, dupOpCode, node, vectorValueReg, valueReg);
             }
             if (length >= 32) {
                 int64_t lenMod32 = length & 0x1f;
                 if (length >= alignmentThresholdLength) {
-                    generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg,
-                        vectorValueReg);
+                    Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg, vectorValueReg);
                     TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
                     if (constantIsUnsignedImm12(length) || constantIsUnsignedImm12Shifted(length)) {
-                        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
+                        Inst_Trg1Src1Imm(cg, OP::addimmx, node, dstEndReg, dstReg, length);
                     } else {
                         loadConstant64(cg, node, length, dstEndReg);
-                        generateTrg1Src2Instruction(cg, OP::addx, node, dstEndReg, dstReg, dstEndReg);
+                        Inst_Trg1Src2(cg, OP::addx, node, dstEndReg, dstReg, dstEndReg);
                     }
                     // N = true, immr:imms = 0xf3b for immediate value ~(0xf)
-                    generateLogicalImmInstruction(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
+                    Inst_LogicalImm(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
                     bool useLoop = (length - 32) > constLoopLen * 2;
                     if (useLoop) {
                         TR::Register *countReg = srm->findOrCreateScratchRegister();
                         loadConstant64(cg, node, (length - 32) / constLoopLen, countReg);
                         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-                        generateLabelInstruction(cg, OP::label, node, loopLabel);
-                        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, countReg, countReg, 1);
+                        Inst_Label(cg, OP::label, node, loopLabel);
+                        Inst_Trg1Src1Imm(cg, OP::subsimmx, node, countReg, countReg, 1);
                         for (int i = 1; i <= 7; i++) {
-                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i * 32),
-                                vectorValueReg, vectorValueReg);
+                            Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i * 32), vectorValueReg,
+                                vectorValueReg);
                         }
-                        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 256), vectorValueReg,
+                        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 256), vectorValueReg,
                             vectorValueReg);
-                        generateConditionalBranchInstruction(cg, node, loopLabel, TR::CC_GT);
+                        Inst_ConditionalBranch(cg, node, loopLabel, TR::CC_GT);
                         srm->reclaimScratchRegister(countReg);
                     }
                     int64_t remainingLength = useLoop ? ((length - 32) % constLoopLen) : (length - 32);
                     for (int i = 32; i <= remainingLength; i += 32) {
-                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
-                            vectorValueReg);
+                        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg, vectorValueReg);
                     }
                     if (lenMod32 <= elementSize) {
                         /*
                          * If (remainingLength mod 32) <= elementSize, then the left over is not larger than 16 bytes.
                          */
-                        generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
+                        Inst_MemSrc1(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
                     } else if (lenMod32 <= (16 + elementSize)) {
                         /*
                          * If (remainingLength mod 32) <= (16 + elementSize), then the left over is not larger than 32
                          * bytes.
                          */
-                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
-                            vectorValueReg, vectorValueReg);
+                        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
+                            vectorValueReg);
                     } else {
-                        generateMemSrc1Instruction(cg, OP::vstrimmq, node,
-                            MRef_disp(cg, dstReg, (remainingLength + 32) & (~0x1f)), vectorValueReg);
+                        Inst_MemSrc1(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, (remainingLength + 32) & (~0x1f)),
+                            vectorValueReg);
                         /* now the left over is not larger than 32 bytes. */
-                        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
-                            vectorValueReg, vectorValueReg);
+                        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
+                            vectorValueReg);
                     }
                     srm->reclaimScratchRegister(dstEndReg);
                 } else {
                     if (lenMod32 == 0) {
                         for (int i = 0; i < length; i += 32) {
-                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
+                            Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
                                 vectorValueReg);
                         }
                     } else {
                         for (int i = 0; i < length - 32; i += 32) {
-                            generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
+                            Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, i), vectorValueReg,
                                 vectorValueReg);
                         }
                         if (lenMod32 == 16) {
-                            generateMemSrc1Instruction(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, length - 16),
-                                vectorValueReg);
+                            Inst_MemSrc1(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, length - 16), vectorValueReg);
                         } else {
                             TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-                            generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
+                            Inst_Trg1Src1Imm(cg, OP::addimmx, node, dstEndReg, dstReg, length);
                             if (lenMod32 > 16) {
-                                generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32),
-                                    vectorValueReg, vectorValueReg);
-                            } else {
-                                generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16),
+                                Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
                                     vectorValueReg);
+                            } else {
+                                Inst_MemSrc1(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
                             }
                             srm->reclaimScratchRegister(dstEndReg);
                         }
@@ -6154,14 +6142,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                 }
             } else if (isPowerOf2(length)) {
                 OP::Mnemonic op = (length == 16) ? OP::vstrimmq : (length == 8) ? OP::vstrimmd : OP::vstrimms;
-                generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
+                Inst_MemSrc1(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
             } else {
                 OP::Mnemonic op = (length >= 16) ? OP::vstrimmq : (length >= 8) ? OP::vstrimmd : OP::vstrimms;
                 int32_t offset = (length >= 16) ? -16 : (length >= 8) ? -8 : -4;
                 TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-                generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, dstEndReg, dstReg, length);
-                generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
-                generateMemSrc1Instruction(cg, op, node, MRef_disp(cg, dstEndReg, offset), vectorValueReg);
+                Inst_Trg1Src1Imm(cg, OP::addimmx, node, dstEndReg, dstReg, length);
+                Inst_MemSrc1(cg, op, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
+                Inst_MemSrc1(cg, op, node, MRef_disp(cg, dstEndReg, offset), vectorValueReg);
                 srm->reclaimScratchRegister(dstEndReg);
             }
         } else {
@@ -6174,14 +6162,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                                                      : OP::vstrimmd;
             valueReg = isValueZero ? cg->allocateRegister() : cg->evaluate(valueNode);
             for (int i = 0; i < length / elementSize; i++) {
-                generateMemSrc1Instruction(cg, strOpCode, node, MRef_disp(cg, dstReg, i * elementSize), valueReg);
+                Inst_MemSrc1(cg, strOpCode, node, MRef_disp(cg, dstReg, i * elementSize), valueReg);
             }
         }
         if ((valueReg != NULL) && isValueZero) {
             TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
             auto *conditions = RegDeps(0, 1, cg);
             conditions->addPostCondition(valueReg, TR::RealRegister::xzr);
-            generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+            Inst_Label(cg, OP::label, node, doneLabel, conditions);
         }
     } else {
         /*
@@ -6243,42 +6231,41 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         const bool needToLoadValueRegToVectorReg
             = (vsplatsImmediateHelper(node, cg, valueNode, valueNode->getDataType(), vectorValueReg)) == NULL;
         if (needToLoadValueRegToVectorReg) {
-            generateTrg1Src1Instruction(cg, dupOpCode, node, vectorValueReg, valueReg);
+            Inst_Trg1Src1(cg, dupOpCode, node, vectorValueReg, valueReg);
         }
 
-        generateLabelInstruction(cg, OP::label, node, startLabel);
-        auto branchToDoneLabelInstr = generateCompareBranchInstruction(cg, OP::cbzx, node, lengthReg, doneLabel);
+        Inst_Label(cg, OP::label, node, startLabel);
+        auto branchToDoneLabelInstr = Inst_CompareBranch(cg, OP::cbzx, node, lengthReg, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr, "Done if length is 0.");
         }
 
         TR::Register *dstEndReg = srm->findOrCreateScratchRegister();
-        generateTrg1Src2Instruction(cg, OP::addx, node, dstEndReg, dstReg, lengthReg);
+        Inst_Trg1Src2(cg, OP::addx, node, dstEndReg, dstReg, lengthReg);
         TR::LabelSymbol *lessThan32Label = generateLabelSymbol(cg);
-        generateCompareImmInstruction(cg, node, lengthReg, 32, true);
-        auto branchToLessThan32LabelInstr = generateConditionalBranchInstruction(cg, node, lessThan32Label, TR::CC_CC);
+        Inst_CompareImm(cg, node, lengthReg, 32, true);
+        auto branchToLessThan32LabelInstr = Inst_ConditionalBranch(cg, node, lessThan32Label, TR::CC_CC);
 
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg, vectorValueReg);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 0), vectorValueReg, vectorValueReg);
 
         TR::LabelSymbol *lessThanOrEqual96Label = generateLabelSymbol(cg);
-        generateCompareImmInstruction(cg, node, lengthReg, 96, true);
-        auto branchToLessThanOrEqual96LabelInstr
-            = generateConditionalBranchInstruction(cg, node, lessThanOrEqual96Label, TR::CC_LS);
+        Inst_CompareImm(cg, node, lengthReg, 96, true);
+        auto branchToLessThanOrEqual96LabelInstr = Inst_ConditionalBranch(cg, node, lessThanOrEqual96Label, TR::CC_LS);
         if (debugObj) {
             debugObj->addInstructionComment(branchToLessThan32LabelInstr, "Jumps to lessThan32Label if length < 32.");
             debugObj->addInstructionComment(branchToLessThanOrEqual96LabelInstr,
                 "Jumps to lessThanOrEqual96Label if length <= 96.");
         }
 
-        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, lengthReg, lengthReg, 96);
+        Inst_Trg1Src1Imm(cg, OP::subimmx, node, lengthReg, lengthReg, 96);
         /* Makes dst address 16 byte aligned */
         TR::Register *remainderReg = srm->findOrCreateScratchRegister();
 
         // N = true, immr:imms = 3 for immediate value 0xf
-        auto mod16OfDstInstr = generateLogicalImmInstruction(cg, OP::andimmx, node, remainderReg, dstReg, true, 3);
-        generateTrg1Src2Instruction(cg, OP::addx, node, lengthReg, lengthReg, remainderReg);
+        auto mod16OfDstInstr = Inst_LogicalImm(cg, OP::andimmx, node, remainderReg, dstReg, true, 3);
+        Inst_Trg1Src2(cg, OP::addx, node, lengthReg, lengthReg, remainderReg);
         // N = true, immr:imms = 0xf3b for immediate value ~(0xf)
-        auto dstAdjustmentInstr = generateLogicalImmInstruction(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
+        auto dstAdjustmentInstr = Inst_LogicalImm(cg, OP::andimmx, node, dstReg, dstReg, true, 0xf3b);
 
         if (debugObj) {
             debugObj->addInstructionComment(mod16OfDstInstr, "The modulo 16 residue of src address.");
@@ -6289,14 +6276,14 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         srm->reclaimScratchRegister(remainderReg);
 
         TR::LabelSymbol *mainLoopLabel = generateLabelSymbol(cg);
-        auto mainLoopLabelInstr = generateLabelInstruction(cg, OP::label, node, mainLoopLabel);
-        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 64);
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
-        auto branchBackToMainLoopLabelInstr = generateConditionalBranchInstruction(cg, node, mainLoopLabel, TR::CC_HI);
-        auto adjustDstRegInstr = generateTrg1Src2Instruction(cg, OP::addx, node, dstReg, dstReg, lengthReg);
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
+        auto mainLoopLabelInstr = Inst_Label(cg, OP::label, node, mainLoopLabel);
+        Inst_Trg1Src1Imm(cg, OP::subsimmx, node, lengthReg, lengthReg, 64);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
+        auto branchBackToMainLoopLabelInstr = Inst_ConditionalBranch(cg, node, mainLoopLabel, TR::CC_HI);
+        auto adjustDstRegInstr = Inst_Trg1Src2(cg, OP::addx, node, dstReg, dstReg, lengthReg);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 64), vectorValueReg, vectorValueReg);
 
         if (debugObj) {
             debugObj->addInstructionComment(mainLoopLabelInstr, "mainLoopLabel");
@@ -6305,20 +6292,18 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
             debugObj->addInstructionComment(adjustDstRegInstr,
                 "Adjusts dst register so that they point to 64bytes before the end");
         }
-        auto branchToDoneLabelInstr2 = generateLabelInstruction(cg, OP::b, node, doneLabel);
+        auto branchToDoneLabelInstr2 = Inst_Label(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr2, "Jumps to doneLabel.");
         }
 
         TR::LabelSymbol *lessThan64Label = generateLabelSymbol(cg);
-        auto lessThanOrEqual96LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThanOrEqual96Label);
-        auto branchToLessThan64LabelInstr
-            = generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 6, lessThan64Label);
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
-        auto lessThan64LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan64Label);
-        generateMemSrc2Instruction(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg,
-            vectorValueReg);
-        auto branchToDoneLabelInstr3 = generateLabelInstruction(cg, OP::b, node, doneLabel);
+        auto lessThanOrEqual96LabelInstr = Inst_Label(cg, OP::label, node, lessThanOrEqual96Label);
+        auto branchToLessThan64LabelInstr = Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 6, lessThan64Label);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstReg, 32), vectorValueReg, vectorValueReg);
+        auto lessThan64LabelInstr = Inst_Label(cg, OP::label, node, lessThan64Label);
+        Inst_MemSrc2(cg, OP::vstpoffq, node, MRef_disp(cg, dstEndReg, -32), vectorValueReg, vectorValueReg);
+        auto branchToDoneLabelInstr3 = Inst_Label(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(lessThanOrEqual96LabelInstr, "lessThanOrEqual96Label");
             debugObj->addInstructionComment(branchToLessThan64LabelInstr, "Jumps to lessThan64Label if length < 64.");
@@ -6327,31 +6312,30 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         }
 
         TR::LabelSymbol *lessThan16Label = generateLabelSymbol(cg);
-        auto lessThan32LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan32Label);
-        auto branchToLessThan16LabelInstr
-            = generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 4, lessThan16Label);
+        auto lessThan32LabelInstr = Inst_Label(cg, OP::label, node, lessThan32Label);
+        auto branchToLessThan16LabelInstr = Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 4, lessThan16Label);
 
         if (debugObj) {
             debugObj->addInstructionComment(lessThan32LabelInstr, "lessThan32Label");
             debugObj->addInstructionComment(branchToLessThan16LabelInstr, "Jumps to lessThan16Label if length < 16.");
         }
 
-        generateMemSrc1Instruction(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
-        generateMemSrc1Instruction(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
+        Inst_MemSrc1(cg, OP::vstrimmq, node, MRef_disp(cg, dstReg, 0), vectorValueReg);
+        Inst_MemSrc1(cg, OP::vsturq, node, MRef_disp(cg, dstEndReg, -16), vectorValueReg);
 
-        auto branchToDoneLabelInstr4 = generateLabelInstruction(cg, OP::b, node, doneLabel);
+        auto branchToDoneLabelInstr4 = Inst_Label(cg, OP::b, node, doneLabel);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDoneLabelInstr4, "Jumps to doneLabel.");
         }
 
-        auto lessThan16LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan16Label);
+        auto lessThan16LabelInstr = Inst_Label(cg, OP::label, node, lessThan16Label);
         if (elementSize == 8) {
-            generateMemSrc1Instruction(cg, valueNode->getDataType().isFloatingPoint() ? OP::vstrimmd : OP::strimmx,
-                node, MRef_disp(cg, dstReg, 0), valueReg);
+            Inst_MemSrc1(cg, valueNode->getDataType().isFloatingPoint() ? OP::vstrimmd : OP::strimmx, node,
+                MRef_disp(cg, dstReg, 0), valueReg);
         } else {
             TR::LabelSymbol *elementLoopLabel = generateLabelSymbol(cg);
-            auto elementLoopLabelInstr = generateLabelInstruction(cg, OP::label, node, elementLoopLabel);
-            generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, elementSize);
+            auto elementLoopLabelInstr = Inst_Label(cg, OP::label, node, elementLoopLabel);
+            Inst_Trg1Src1Imm(cg, OP::subsimmx, node, lengthReg, lengthReg, elementSize);
             const OP::Mnemonic strOpCode = (!valueNode->getDataType().isFloatingPoint())
                 ? ((elementSize == 1)          ? OP::strbpost
                           : (elementSize == 2) ? OP::strhpost
@@ -6359,9 +6343,8 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                                                : OP::strpostx)
                 : valueNode->getDataType().isFloat() ? OP::vstrposts
                                                      : OP::vstrpostd;
-            generateMemSrc1Instruction(cg, strOpCode, node, MRef_disp(cg, dstReg, elementSize), valueReg);
-            auto branchBackToElementLoopLabelInstr
-                = generateConditionalBranchInstruction(cg, node, elementLoopLabel, TR::CC_HI);
+            Inst_MemSrc1(cg, strOpCode, node, MRef_disp(cg, dstReg, elementSize), valueReg);
+            auto branchBackToElementLoopLabelInstr = Inst_ConditionalBranch(cg, node, elementLoopLabel, TR::CC_HI);
             if (debugObj) {
                 debugObj->addInstructionComment(lessThan16LabelInstr, "lessThan16Label");
                 debugObj->addInstructionComment(elementLoopLabelInstr, "elementLoopLabel");
@@ -6377,7 +6360,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
         conditions->addPostCondition(valueReg, isValueZero ? TR::RealRegister::xzr : TR::RealRegister::NoReg);
         srm->addScratchRegistersToDependencyList(conditions);
 
-        auto doneLabelInstr = generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+        auto doneLabelInstr = Inst_Label(cg, OP::label, node, doneLabel, conditions);
         if (debugObj) {
             debugObj->addInstructionComment(doneLabelInstr, "doneLabel");
         }
@@ -6512,7 +6495,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     TR::Register *src1Reg;
     if ((src1Node->getReferenceCount() > 1) || isArrayCmpLen) {
         src1Reg = srm->findOrCreateScratchRegister();
-        generateMovInstruction(cg, node, src1Reg, savedSrc1Reg);
+        Inst_Mov(cg, node, src1Reg, savedSrc1Reg);
     } else {
         src1Reg = savedSrc1Reg;
     }
@@ -6526,22 +6509,22 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(cg, OP::label, node, startLabel);
+    Inst_Label(cg, OP::label, node, startLabel);
     if (isArrayCmpLen) {
-        generateMovInstruction(cg, node, resultReg, lengthReg, true);
+        Inst_Mov(cg, node, resultReg, lengthReg, true);
     } else {
         loadConstant32(cg, node, 0, resultReg);
     }
-    generateCompareInstruction(cg, node, src1Reg, src2Reg, true);
+    Inst_Compare(cg, node, src1Reg, src2Reg, true);
     if (!isLengthGreaterThan15) {
-        auto ccmpLengthInstr = generateConditionalCompareImmInstruction(cg, node, lengthReg, 0, 4, TR::CC_NE,
+        auto ccmpLengthInstr = Inst_ConditionalCompareImm(cg, node, lengthReg, 0, 4, TR::CC_NE,
             /* is64bit */ true); /* 4 for Z flag */
         if (debugObj) {
             debugObj->addInstructionComment(ccmpLengthInstr,
                 "Compares lengthReg with 0 if src1 and src2 are not the same array. Otherwise, sets EQ flag.");
         }
     }
-    auto branchToDoneLabelInstr = generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
+    auto branchToDoneLabelInstr = Inst_ConditionalBranch(cg, node, doneLabel, TR::CC_EQ);
     if (debugObj) {
         debugObj->addInstructionComment(branchToDoneLabelInstr,
             "Done if src1 and src2 are the same array or length is 0.");
@@ -6556,28 +6539,28 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     TR::Register *data3Reg = srm->findOrCreateScratchRegister();
     TR::Register *data4Reg = srm->findOrCreateScratchRegister();
     if (!isLengthGreaterThan15) {
-        generateCompareImmInstruction(cg, node, lengthReg, 16, /* is64bit */ true);
-        auto branchToLessThan16LabelInstr = generateConditionalBranchInstruction(cg, node, lessThan16Label, TR::CC_CC);
+        Inst_CompareImm(cg, node, lengthReg, 16, /* is64bit */ true);
+        auto branchToLessThan16LabelInstr = Inst_ConditionalBranch(cg, node, lessThan16Label, TR::CC_CC);
         if (debugObj) {
             debugObj->addInstructionComment(branchToLessThan16LabelInstr, "Jumps to lessThan16Label if length < 16.");
         }
     }
-    generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, lengthReg, lengthReg, 16);
+    Inst_Trg1Src1Imm(cg, OP::subimmx, node, lengthReg, lengthReg, 16);
 
     TR::LabelSymbol *loop16Label = generateLabelSymbol(cg);
     {
-        auto loop16LabelInstr = generateLabelInstruction(cg, OP::label, node, loop16Label);
-        generateTrg2MemInstruction(cg, OP::ldppostx, node, data1Reg, data3Reg, MRef_disp(cg, src1Reg, 16));
-        generateTrg2MemInstruction(cg, OP::ldppostx, node, data2Reg, data4Reg, MRef_disp(cg, src2Reg, 16));
+        auto loop16LabelInstr = Inst_Label(cg, OP::label, node, loop16Label);
+        Inst_Trg2Mem(cg, OP::ldppostx, node, data1Reg, data3Reg, MRef_disp(cg, src1Reg, 16));
+        Inst_Trg2Mem(cg, OP::ldppostx, node, data2Reg, data4Reg, MRef_disp(cg, src2Reg, 16));
         if (isArrayCmpLen) {
-            generateTrg1Src2Instruction(cg, OP::subsx, node, data1Reg, data1Reg, data2Reg);
+            Inst_Trg1Src2(cg, OP::subsx, node, data1Reg, data1Reg, data2Reg);
         } else {
-            generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
+            Inst_Compare(cg, node, data1Reg, data2Reg, true);
         }
-        generateConditionalCompareInstruction(cg, node, data3Reg, data4Reg, 0, TR::CC_EQ, true);
-        auto branchToNotEqual16LabelInstr2 = generateConditionalBranchInstruction(cg, node, notEqual16Label, TR::CC_NE);
-        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 16);
-        auto branchBacktoLoop16LabelInstr = generateConditionalBranchInstruction(cg, node, loop16Label, TR::CC_CS);
+        Inst_ConditionalCompare(cg, node, data3Reg, data4Reg, 0, TR::CC_EQ, true);
+        auto branchToNotEqual16LabelInstr2 = Inst_ConditionalBranch(cg, node, notEqual16Label, TR::CC_NE);
+        Inst_Trg1Src1Imm(cg, OP::subsimmx, node, lengthReg, lengthReg, 16);
+        auto branchBacktoLoop16LabelInstr = Inst_ConditionalBranch(cg, node, loop16Label, TR::CC_CS);
         if (debugObj) {
             debugObj->addInstructionComment(loop16LabelInstr, "loop16Label");
             debugObj->addInstructionComment(branchToNotEqual16LabelInstr2,
@@ -6587,12 +6570,12 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     }
     if (isLengthGreaterThan15) {
-        generateCompareImmInstruction(cg, node, lengthReg, -16, true);
-        auto branchToDoneLabelInstr3 = generateConditionalBranchInstruction(cg, node, done0Label, TR::CC_EQ);
-        auto adjustSrc1RegInstr = generateTrg1Src2Instruction(cg, OP::addx, node, src1Reg, src1Reg, lengthReg);
-        generateTrg1Src2Instruction(cg, OP::addx, node, src2Reg, src2Reg, lengthReg);
+        Inst_CompareImm(cg, node, lengthReg, -16, true);
+        auto branchToDoneLabelInstr3 = Inst_ConditionalBranch(cg, node, done0Label, TR::CC_EQ);
+        auto adjustSrc1RegInstr = Inst_Trg1Src2(cg, OP::addx, node, src1Reg, src1Reg, lengthReg);
+        Inst_Trg1Src2(cg, OP::addx, node, src2Reg, src2Reg, lengthReg);
         loadConstant64(cg, node, 0, lengthReg);
-        auto branchBacktoLoop16LabelInstr = generateLabelInstruction(cg, OP::b, node, loop16Label);
+        auto branchBacktoLoop16LabelInstr = Inst_Label(cg, OP::b, node, loop16Label);
         if (debugObj) {
             if (isArrayCmpLen) {
                 debugObj->addInstructionComment(branchToDoneLabelInstr3,
@@ -6607,11 +6590,11 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     } else {
         TR::Instruction *branchToDoneLabelInstr3;
-        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, lengthReg, lengthReg, 16);
+        Inst_Trg1Src1Imm(cg, OP::addimmx, node, lengthReg, lengthReg, 16);
         branchToDoneLabelInstr3
-            = generateCompareBranchInstruction(cg, OP::cbzx, node, lengthReg, isArrayCmpLen ? done0Label : doneLabel);
+            = Inst_CompareBranch(cg, OP::cbzx, node, lengthReg, isArrayCmpLen ? done0Label : doneLabel);
 
-        auto branchToLessThan16Label2 = generateLabelInstruction(cg, OP::b, node, lessThan16Label);
+        auto branchToLessThan16Label2 = Inst_Label(cg, OP::b, node, lessThan16Label);
 
         if (debugObj) {
             if (isArrayCmpLen) {
@@ -6625,7 +6608,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
         }
     }
 
-    auto notEqual16LabelInstr = generateLabelInstruction(cg, OP::label, node, notEqual16Label);
+    auto notEqual16LabelInstr = Inst_Label(cg, OP::label, node, notEqual16Label);
     if (debugObj) {
         debugObj->addInstructionComment(notEqual16LabelInstr,
             "notEqual16Label. src register points 16-byte ahead of the location where the data in the registers was "
@@ -6633,16 +6616,16 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
 
     if (isArrayCmpLen) {
-        generateTrg1Src2Instruction(cg, OP::eorx, node, data3Reg, data3Reg, data4Reg);
-        generateCompareImmInstruction(cg, node, data1Reg, 0, true);
-        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
+        Inst_Trg1Src2(cg, OP::eorx, node, data3Reg, data3Reg, data4Reg);
+        Inst_CompareImm(cg, node, data1Reg, 0, true);
+        Inst_CondTrg1Src2(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
         loadConstant32(cg, node, 1, data2Reg);
-        auto getOffsetInstr = generateCIncInstruction(cg, node, data2Reg, data2Reg, TR::CC_NE, true);
+        auto getOffsetInstr = Inst_CInc(cg, node, data2Reg, data2Reg, TR::CC_NE, true);
         auto adjustingBaseAddrInstr
-            = generateTrg1Src2ShiftedInstruction(cg, OP::subx, node, src1Reg, src1Reg, data2Reg, TR::SH_LSL, 3);
-        generateTrg1Src1Instruction(cg, OP::rbitx, node, data1Reg, data1Reg);
-        auto getMismatchLocationInstr = generateTrg1Src1Instruction(cg, OP::clzx, node, data1Reg, data1Reg);
-        generateTrg1Src2ShiftedInstruction(cg, OP::addx, node, src1Reg, src1Reg, data1Reg, TR::SH_LSR, 3);
+            = Inst_Trg1Src2Shifted(cg, OP::subx, node, src1Reg, src1Reg, data2Reg, TR::SH_LSL, 3);
+        Inst_Trg1Src1(cg, OP::rbitx, node, data1Reg, data1Reg);
+        auto getMismatchLocationInstr = Inst_Trg1Src1(cg, OP::clzx, node, data1Reg, data1Reg);
+        Inst_Trg1Src2Shifted(cg, OP::addx, node, src1Reg, src1Reg, data1Reg, TR::SH_LSR, 3);
         if (debugObj) {
             debugObj->addInstructionComment(getOffsetInstr,
                 "register has 1 if mismatch is in the first 8-byte data. Otherwise it has 2.");
@@ -6651,25 +6634,24 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
             debugObj->addInstructionComment(getMismatchLocationInstr, "Gets the bit position of the first mismatch.");
         }
     } else {
-        generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
-        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
-        generateCondTrg1Src2Instruction(cg, OP::cselx, node, data2Reg, data2Reg, data4Reg, TR::CC_NE);
-        generateTrg1Src1Instruction(cg, OP::revx, node, data1Reg, data1Reg);
-        generateTrg1Src1Instruction(cg, OP::revx, node, data2Reg, data2Reg);
+        Inst_Compare(cg, node, data1Reg, data2Reg, true);
+        Inst_CondTrg1Src2(cg, OP::cselx, node, data1Reg, data1Reg, data3Reg, TR::CC_NE);
+        Inst_CondTrg1Src2(cg, OP::cselx, node, data2Reg, data2Reg, data4Reg, TR::CC_NE);
+        Inst_Trg1Src1(cg, OP::revx, node, data1Reg, data1Reg);
+        Inst_Trg1Src1(cg, OP::revx, node, data2Reg, data2Reg);
     }
     srm->reclaimScratchRegister(data3Reg);
     srm->reclaimScratchRegister(data4Reg);
 
     if (!isLengthGreaterThan15) {
-        auto branchToDone0LabelInstr = generateLabelInstruction(cg, OP::b, node, done0Label);
+        auto branchToDone0LabelInstr = Inst_Label(cg, OP::b, node, done0Label);
 
-        auto lessThan16LabelInstr = generateLabelInstruction(cg, OP::label, node, lessThan16Label);
-        generateTrg1Src1ImmInstruction(cg, OP::subsimmx, node, lengthReg, lengthReg, 1);
-        generateTrg1MemInstruction(cg, OP::ldrbpost, node, data1Reg, MRef_disp(cg, src1Reg, 1));
-        generateTrg1MemInstruction(cg, OP::ldrbpost, node, data2Reg, MRef_disp(cg, src2Reg, 1));
-        generateConditionalCompareInstruction(cg, node, data1Reg, data2Reg, 0, TR::CC_HI);
-        auto branchBacktoLessThan16LabelInstr
-            = generateConditionalBranchInstruction(cg, node, lessThan16Label, TR::CC_EQ);
+        auto lessThan16LabelInstr = Inst_Label(cg, OP::label, node, lessThan16Label);
+        Inst_Trg1Src1Imm(cg, OP::subsimmx, node, lengthReg, lengthReg, 1);
+        Inst_Trg1Mem(cg, OP::ldrbpost, node, data1Reg, MRef_disp(cg, src1Reg, 1));
+        Inst_Trg1Mem(cg, OP::ldrbpost, node, data2Reg, MRef_disp(cg, src2Reg, 1));
+        Inst_ConditionalCompare(cg, node, data1Reg, data2Reg, 0, TR::CC_HI);
+        auto branchBacktoLessThan16LabelInstr = Inst_ConditionalBranch(cg, node, lessThan16Label, TR::CC_EQ);
         if (debugObj) {
             debugObj->addInstructionComment(branchToDone0LabelInstr, "Jumps to done0Label.");
             debugObj->addInstructionComment(lessThan16LabelInstr, "lessThan16Label");
@@ -6677,11 +6659,11 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
                 "Jumps to lessThan16Label (byteloop) if the remaining length > 0 and no mismatch is found");
         }
         if (isArrayCmpLen) {
-            generateCompareInstruction(cg, node, data1Reg, data2Reg);
+            Inst_Compare(cg, node, data1Reg, data2Reg);
 
             TR::Register *offReg = srm->findOrCreateScratchRegister();
-            generateCSetInstruction(cg, node, offReg, TR::CC_NE);
-            auto adjustSrc1AddrInstr = generateTrg1Src2Instruction(cg, OP::subx, node, src1Reg, src1Reg, offReg);
+            Inst_CSet(cg, node, offReg, TR::CC_NE);
+            auto adjustSrc1AddrInstr = Inst_Trg1Src2(cg, OP::subx, node, src1Reg, src1Reg, offReg);
             if (debugObj) {
                 debugObj->addInstructionComment(adjustSrc1AddrInstr,
                     "Subtracts 1 from src1 if the mismatch is found in the last byte of data.");
@@ -6690,16 +6672,16 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     }
 
     if (isArrayCmpLen) {
-        auto done0LabelInstr = generateLabelInstruction(cg, OP::label, node, done0Label);
-        generateTrg1Src2Instruction(cg, OP::subx, node, resultReg, src1Reg, savedSrc1Reg);
+        auto done0LabelInstr = Inst_Label(cg, OP::label, node, done0Label);
+        Inst_Trg1Src2(cg, OP::subx, node, resultReg, src1Reg, savedSrc1Reg);
         if (debugObj) {
             debugObj->addInstructionComment(done0LabelInstr, "done0Label");
         }
     } else {
-        auto done0LabelInstr = generateLabelInstruction(cg, OP::label, node, done0Label); /* Result: 0, 1 or 2 */
-        generateCompareInstruction(cg, node, data1Reg, data2Reg, true);
-        generateCSetInstruction(cg, node, resultReg, TR::CC_NE);
-        generateCIncInstruction(cg, node, resultReg, resultReg, TR::CC_HI, false);
+        auto done0LabelInstr = Inst_Label(cg, OP::label, node, done0Label); /* Result: 0, 1 or 2 */
+        Inst_Compare(cg, node, data1Reg, data2Reg, true);
+        Inst_CSet(cg, node, resultReg, TR::CC_NE);
+        Inst_CInc(cg, node, resultReg, resultReg, TR::CC_HI, false);
         if (debugObj) {
             debugObj->addInstructionComment(done0LabelInstr, "done0Label");
         }
@@ -6713,7 +6695,7 @@ static TR::Register *arraycmpEvaluatorHelper(TR::Node *node, TR::CodeGenerator *
     conditions->addPostCondition(resultReg, TR::RealRegister::NoReg);
     srm->addScratchRegistersToDependencyList(conditions);
 
-    auto doneLabelInstr = generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+    auto doneLabelInstr = Inst_Label(cg, OP::label, node, doneLabel, conditions);
     if (debugObj) {
         debugObj->addInstructionComment(doneLabelInstr, "doneLabel");
     }
@@ -6762,30 +6744,30 @@ static void inlineConstantLengthForwardArrayCopy(TR::Node *node, int64_t byteLen
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        Inst_Label(cg, OP::label, node, loopLabel);
 
         // Copy 32x4 bytes in a loop
-        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, cntReg, cntReg, 1);
-        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
-        generateCompareBranchInstruction(cg, OP::cbnzx, node, cntReg, loopLabel);
+        Inst_Trg2Mem(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        Inst_Trg1Src1Imm(cg, OP::subimmx, node, cntReg, cntReg, 1);
+        Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        Inst_CompareBranch(cg, OP::cbnzx, node, cntReg, loopLabel);
 
         TR::LabelSymbol *loopEndLabel = generateLabelSymbol(cg);
         loopEndLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopEndLabel, deps);
+        Inst_Label(cg, OP::label, node, loopEndLabel, deps);
     } else if (iteration == 1) {
         residue += 128;
     }
 
     while (residue >= 32) {
-        generateTrg2MemInstruction(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
-        generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppostq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, 32));
+        Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstReg, 32), dataReg1, dataReg2);
         residue -= 32;
     }
 
@@ -6818,8 +6800,8 @@ static void inlineConstantLengthForwardArrayCopy(TR::Node *node, int64_t byteLen
             dataSize = 1;
         }
 
-        generateTrg1MemInstruction(cg, loadOp, node, dataReg, MRef_disp(cg, srcReg, offset));
-        generateMemSrc1Instruction(cg, storeOp, node, MRef_disp(cg, dstReg, offset), dataReg);
+        Inst_Trg1Mem(cg, loadOp, node, dataReg, MRef_disp(cg, srcReg, offset));
+        Inst_MemSrc1(cg, storeOp, node, MRef_disp(cg, dstReg, offset), dataReg);
         offset += dataSize;
         residue -= dataSize;
     }
@@ -6861,30 +6843,30 @@ static void inlineConstantLengthBackwardArrayCopy(TR::Node *node, int64_t byteLe
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        Inst_Label(cg, OP::label, node, loopLabel);
 
         // Copy 32x4 bytes in a loop
-        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateTrg1Src1ImmInstruction(cg, OP::subimmx, node, cntReg, cntReg, 1);
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
-        generateCompareBranchInstruction(cg, OP::cbnzx, node, cntReg, loopLabel);
+        Inst_Trg2Mem(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        Inst_Trg1Src1Imm(cg, OP::subimmx, node, cntReg, cntReg, 1);
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        Inst_CompareBranch(cg, OP::cbnzx, node, cntReg, loopLabel);
 
         TR::LabelSymbol *loopEndLabel = generateLabelSymbol(cg);
         loopEndLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopEndLabel, deps);
+        Inst_Label(cg, OP::label, node, loopEndLabel, deps);
     } else if (iteration == 1) {
         residue += 128;
     }
 
     while (residue >= 32) {
-        generateTrg2MemInstruction(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
-        generateMemSrc2Instruction(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
+        Inst_Trg2Mem(cg, OP::vldppreq, node, dataReg1, dataReg2, MRef_disp(cg, srcReg, -32));
+        Inst_MemSrc2(cg, OP::vstppreq, node, MRef_disp(cg, dstReg, -32), dataReg1, dataReg2);
         residue -= 32;
     }
 
@@ -6916,8 +6898,8 @@ static void inlineConstantLengthBackwardArrayCopy(TR::Node *node, int64_t byteLe
             dataSize = 1;
         }
 
-        generateTrg1MemInstruction(cg, loadOp, node, dataReg, MRef_disp(cg, srcReg, -dataSize));
-        generateMemSrc1Instruction(cg, storeOp, node, MRef_disp(cg, dstReg, -dataSize), dataReg);
+        Inst_Trg1Mem(cg, loadOp, node, dataReg, MRef_disp(cg, srcReg, -dataSize));
+        Inst_MemSrc1(cg, storeOp, node, MRef_disp(cg, dstReg, -dataSize), dataReg);
         residue -= dataSize;
     }
 
@@ -6944,7 +6926,7 @@ bool OMR::ARM64::TreeEvaluator::stopUsingCopyReg(TR::Node *node, TR::Register *&
             } else {
                 copyReg = cg->allocateCollectedReferenceRegister();
             }
-            generateMovInstruction(cg, node, copyReg, reg);
+            Inst_Mov(cg, node, copyReg, reg);
             reg = copyReg;
             return true;
         }
@@ -6962,15 +6944,14 @@ static void generateCallToArrayCopyHelper(TR::Node *node, TR::Register *srcAddrR
         helper = TR_ARM64forwardArrayCopy;
     } else if (node->isBackwardArrayCopy()) {
         // Adjusting src and dst addresses
-        generateTrg1Src2Instruction(cg, OP::addx, node, srcAddrReg, srcAddrReg, lengthReg);
-        generateTrg1Src2Instruction(cg, OP::addx, node, dstAddrReg, dstAddrReg, lengthReg);
+        Inst_Trg1Src2(cg, OP::addx, node, srcAddrReg, srcAddrReg, lengthReg);
+        Inst_Trg1Src2(cg, OP::addx, node, dstAddrReg, dstAddrReg, lengthReg);
         helper = TR_ARM64backwardArrayCopy;
     }
 
     TR::SymbolReference *arrayCopyHelper = cg->symRefTab()->findOrCreateRuntimeHelper(helper, false, false, false);
 
-    generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), deps, arrayCopyHelper,
-        NULL);
+    Inst_ImmSym(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), deps, arrayCopyHelper, NULL);
     cg->machine()->setLinkRegisterKilled(true);
 
     return;
@@ -6989,15 +6970,14 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
     cg->getARM64OutOfLineCodeSectionList().push_front(oolSection);
     oolSection->swapInstructionListsWithCompilation();
 
-    generateLabelInstruction(cg, OP::label, node, oolArraycopyLabel);
+    Inst_Label(cg, OP::label, node, oolArraycopyLabel);
 
     TR::SymbolReference *arrayCopyHelper
         = cg->symRefTab()->findOrCreateRuntimeHelper(TR_ARM64arrayCopy, false, false, false);
 
-    generateImmSymInstruction(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), NULL, arrayCopyHelper,
-        NULL);
+    Inst_ImmSym(cg, OP::bl, node, (uintptr_t)arrayCopyHelper->getMethodAddress(), NULL, arrayCopyHelper, NULL);
 
-    generateLabelInstruction(cg, OP::b, node, doneLabel);
+    Inst_Label(cg, OP::b, node, doneLabel);
 
     cg->machine()->setLinkRegisterKilled(true);
     oolSection->swapInstructionListsWithCompilation();
@@ -7019,74 +6999,74 @@ static void inlinePrimitiveForwardArraycopy(TR::Node *node, TR::Register *srcAdd
 
     static const char *breakOnInlineArraycopy = feGetEnv("TR_BreakOnInlineArraycopy");
     if (breakOnInlineArraycopy) {
-        generateExceptionInstruction(cg, OP::brkarm64, node, 0);
+        Inst_Exception(cg, OP::brkarm64, node, 0);
     }
 
     const int32_t inlineThresholdBytes = 63;
-    generateCompareImmInstruction(cg, node, lengthReg, inlineThresholdBytes, true);
-    generateConditionalBranchInstruction(cg, node, oolArraycopyLabel, TR::CC_HI);
+    Inst_CompareImm(cg, node, lengthReg, inlineThresholdBytes, true);
+    Inst_ConditionalBranch(cg, node, oolArraycopyLabel, TR::CC_HI);
 
-    generateTrg1Src2Instruction(cg, OP::subsx, node, x3ScratchReg, dstAddrReg, srcAddrReg);
+    Inst_Trg1Src2(cg, OP::subsx, node, x3ScratchReg, dstAddrReg, srcAddrReg);
 
     // Skip if src and dest are the same
     //
-    generateConditionalBranchInstruction(cg, node, doneLabel, TR::CC_EQ);
+    Inst_ConditionalBranch(cg, node, doneLabel, TR::CC_EQ);
 
     if (!node->isForwardArrayCopy()) {
         // Check for forward arraycopy dynamically if not known.  Forward arraycopies should be
         // the more common case and are optimized inline.
         //
-        generateCompareInstruction(cg, node, lengthReg, x3ScratchReg, true);
-        generateConditionalBranchInstruction(cg, node, oolArraycopyLabel, TR::CC_HI);
+        Inst_Compare(cg, node, lengthReg, x3ScratchReg, true);
+        Inst_ConditionalBranch(cg, node, oolArraycopyLabel, TR::CC_HI);
     }
 
     // Copy 32 bytes
     //
     TR::LabelSymbol *fwAC16Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 5, fwAC16Label);
-    generateTrg2MemInstruction(cg, OP::vldppostq, node, v30ScratchReg, v31ScratchReg, MRef_disp(cg, srcAddrReg, 32));
-    generateMemSrc2Instruction(cg, OP::vstppostq, node, MRef_disp(cg, dstAddrReg, 32), v30ScratchReg, v31ScratchReg);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 5, fwAC16Label);
+    Inst_Trg2Mem(cg, OP::vldppostq, node, v30ScratchReg, v31ScratchReg, MRef_disp(cg, srcAddrReg, 32));
+    Inst_MemSrc2(cg, OP::vstppostq, node, MRef_disp(cg, dstAddrReg, 32), v30ScratchReg, v31ScratchReg);
 
     // Copy 16 bytes
     //
-    generateLabelInstruction(cg, OP::label, node, fwAC16Label);
+    Inst_Label(cg, OP::label, node, fwAC16Label);
     TR::LabelSymbol *fwAC8Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 4, fwAC8Label);
-    generateTrg1MemInstruction(cg, OP::vldrpostq, node, v30ScratchReg, MRef_disp(cg, srcAddrReg, 16));
-    generateMemSrc1Instruction(cg, OP::vstrpostq, node, MRef_disp(cg, dstAddrReg, 16), v30ScratchReg);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 4, fwAC8Label);
+    Inst_Trg1Mem(cg, OP::vldrpostq, node, v30ScratchReg, MRef_disp(cg, srcAddrReg, 16));
+    Inst_MemSrc1(cg, OP::vstrpostq, node, MRef_disp(cg, dstAddrReg, 16), v30ScratchReg);
 
     // Copy 8 bytes
     //
-    generateLabelInstruction(cg, OP::label, node, fwAC8Label);
+    Inst_Label(cg, OP::label, node, fwAC8Label);
     TR::LabelSymbol *fwAC4Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 3, fwAC4Label);
-    generateTrg1MemInstruction(cg, OP::ldrpostx, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 8));
-    generateMemSrc1Instruction(cg, OP::strpostx, node, MRef_disp(cg, dstAddrReg, 8), x3ScratchReg);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 3, fwAC4Label);
+    Inst_Trg1Mem(cg, OP::ldrpostx, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 8));
+    Inst_MemSrc1(cg, OP::strpostx, node, MRef_disp(cg, dstAddrReg, 8), x3ScratchReg);
 
     // Copy 4 bytes
     //
-    generateLabelInstruction(cg, OP::label, node, fwAC4Label);
+    Inst_Label(cg, OP::label, node, fwAC4Label);
     TR::LabelSymbol *fwAC2Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 2, fwAC2Label);
-    generateTrg1MemInstruction(cg, OP::ldrpostw, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 4));
-    generateMemSrc1Instruction(cg, OP::strpostw, node, MRef_disp(cg, dstAddrReg, 4), x3ScratchReg);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 2, fwAC2Label);
+    Inst_Trg1Mem(cg, OP::ldrpostw, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 4));
+    Inst_MemSrc1(cg, OP::strpostw, node, MRef_disp(cg, dstAddrReg, 4), x3ScratchReg);
 
     // Copy 2 bytes
     //
-    generateLabelInstruction(cg, OP::label, node, fwAC2Label);
+    Inst_Label(cg, OP::label, node, fwAC2Label);
     TR::LabelSymbol *fwAC1Label = generateLabelSymbol(cg);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 1, fwAC1Label);
-    generateTrg1MemInstruction(cg, OP::ldrhpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 2));
-    generateMemSrc1Instruction(cg, OP::strhpost, node, MRef_disp(cg, dstAddrReg, 2), x3ScratchReg);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 1, fwAC1Label);
+    Inst_Trg1Mem(cg, OP::ldrhpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 2));
+    Inst_MemSrc1(cg, OP::strhpost, node, MRef_disp(cg, dstAddrReg, 2), x3ScratchReg);
 
     // Copy 1 byte
     //
-    generateLabelInstruction(cg, OP::label, node, fwAC1Label);
-    generateTestBitBranchInstruction(cg, OP::tbz, node, lengthReg, 0, doneLabel);
-    generateTrg1MemInstruction(cg, OP::ldrbpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 1));
-    generateMemSrc1Instruction(cg, OP::strbpost, node, MRef_disp(cg, dstAddrReg, 1), x3ScratchReg);
+    Inst_Label(cg, OP::label, node, fwAC1Label);
+    Inst_TestBitBranch(cg, OP::tbz, node, lengthReg, 0, doneLabel);
+    Inst_Trg1Mem(cg, OP::ldrbpost, node, x3ScratchReg, MRef_disp(cg, srcAddrReg, 1));
+    Inst_MemSrc1(cg, OP::strbpost, node, MRef_disp(cg, dstAddrReg, 1), x3ScratchReg);
 
-    generateLabelInstruction(cg, OP::label, node, doneLabel, deps);
+    Inst_Label(cg, OP::label, node, doneLabel, deps);
 
     cg->stopUsingRegister(x3ScratchReg);
     cg->stopUsingRegister(v30ScratchReg);
@@ -7175,7 +7155,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::
     lengthReg = cg->evaluate(lengthNode);
     if (!cg->canClobberNodesRegister(lengthNode)) {
         TR::Register *lenCopyReg = cg->allocateRegister();
-        generateMovInstruction(cg, lengthNode, lenCopyReg, lengthReg);
+        Inst_Mov(cg, lengthNode, lenCopyReg, lengthReg);
         lengthReg = lenCopyReg;
         stopUsingLenCopyReg = true;
     }
@@ -7297,28 +7277,26 @@ TR::Register *OMR::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
     } else {
         if (mref->useIndexedForm()) {
             resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
-            generateTrg1Src2Instruction(cg, OP::addx, node, resultReg, mref->getBaseRegister(),
-                mref->getIndexRegister());
+            Inst_Trg1Src2(cg, OP::addx, node, resultReg, mref->getBaseRegister(), mref->getIndexRegister());
         } else {
             int32_t offset = mref->getOffset();
             if (mref->hasDelayedOffset() || offset != 0) {
                 resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
                 if (mref->hasDelayedOffset()) {
-                    generateTrg1MemInstruction(cg, OP::addimmx, node, resultReg, mref);
+                    Inst_Trg1Mem(cg, OP::addimmx, node, resultReg, mref);
                 } else {
                     if (offset >= 0 && constantIsUnsignedImm12(offset)) {
-                        generateTrg1Src1ImmInstruction(cg, OP::addimmx, node, resultReg, mref->getBaseRegister(),
-                            offset);
+                        Inst_Trg1Src1Imm(cg, OP::addimmx, node, resultReg, mref->getBaseRegister(), offset);
                     } else {
                         loadConstant64(cg, node, offset, resultReg);
-                        generateTrg1Src2Instruction(cg, OP::addx, node, resultReg, mref->getBaseRegister(), resultReg);
+                        Inst_Trg1Src2(cg, OP::addx, node, resultReg, mref->getBaseRegister(), resultReg);
                     }
                 }
             } else {
                 resultReg = mref->getBaseRegister();
                 if (resultReg == cg->getMethodMetaDataRegister()) {
                     resultReg = cg->allocateRegister();
-                    generateMovInstruction(cg, node, resultReg, mref->getBaseRegister());
+                    Inst_Mov(cg, node, resultReg, mref->getBaseRegister());
                 }
             }
         }
@@ -7423,12 +7401,12 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
         labelSym = generateLabelSymbol(cg);
         node->setLabel(labelSym);
     }
-    TR::Instruction *labelInst = generateLabelInstruction(cg, OP::label, node, labelSym, deps);
+    TR::Instruction *labelInst = Inst_Label(cg, OP::label, node, labelSym, deps);
     labelSym->setInstruction(labelInst);
     block->setFirstInstruction(labelInst);
 
     TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
-    TR::Instruction *fence = generateAdminInstruction(cg, OP::fence, node, fenceNode);
+    TR::Instruction *fence = Inst_Admin(cg, OP::fence, node, fenceNode);
 
     if (block->isCatchBlock()) {
         cg->generateCatchBlockBBStartPrologue(node, fence);
@@ -7468,7 +7446,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::Code
     }
 
     // put the dependencies (if any) on the fence
-    TR::Instruction *instr = generateAdminInstruction(cg, OP::fence, node, deps, fenceNode);
+    TR::Instruction *instr = Inst_Admin(cg, OP::fence, node, deps, fenceNode);
     node->getBlock()->setLastInstruction(instr);
 
     return NULL;
@@ -7497,13 +7475,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR
 
         switch (kind) {
             case TR_GPR:
-                generateMovInstruction(cg, node, copyReg, srcReg);
+                Inst_Mov(cg, node, copyReg, srcReg);
                 break;
             case TR_FPR:
-                generateTrg1Src1Instruction(cg, OP::fmovd, node, copyReg, srcReg);
+                Inst_Trg1Src1(cg, OP::fmovd, node, copyReg, srcReg);
                 break;
             case TR_VRF:
-                generateTrg1Src2Instruction(cg, OP::vorr16b, node, copyReg, srcReg, srcReg);
+                Inst_Trg1Src2(cg, OP::vorr16b, node, copyReg, srcReg, srcReg);
                 break;
             default:
                 TR_ASSERT_FATAL(false, "Unsupported RegisterKind.");
@@ -7611,7 +7589,7 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
          * target register. This needs to be fixed at some point.
          */
-        generateTrg1MemSrc1Instruction(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), newValueReg);
+        Inst_Trg1MemSrc1(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), newValueReg);
     } else {
         /*
          * Generating non-intuitive instruction sequence which uses load exclusive register
@@ -7639,19 +7617,19 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
         TR::Register *oldValueReg = cg->allocateRegister();
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        Inst_Label(cg, OP::label, node, loopLabel);
 
         auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
-        generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
+        Inst_Trg1Mem(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
-        generateTrg1Src2Instruction(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
+        Inst_Trg1Src2(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
 
         // store release exclusive register
         auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
-        generateTrg1MemSrc1Instruction(cg, storeop, node, oldValueReg, MRef_disp(cg, addressReg, 0), newValueReg);
-        generateCompareBranchInstruction(cg, OP::cbnzx, node, oldValueReg, loopLabel);
+        Inst_Trg1MemSrc1(cg, storeop, node, oldValueReg, MRef_disp(cg, addressReg, 0), newValueReg);
+        Inst_CompareBranch(cg, OP::cbnzx, node, oldValueReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         auto conditions = RegDeps(0, 4, cg);
@@ -7662,7 +7640,7 @@ static TR::Register *intrinsicAtomicAdd(TR::Node *node, TR::CodeGenerator *cg)
         conditions->addPostCondition(valueReg, TR::RealRegister::NoReg);
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+        Inst_Label(cg, OP::label, node, doneLabel, conditions);
         cg->stopUsingRegister(oldValueReg);
     }
 
@@ -7720,7 +7698,7 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
          * target register. This needs to be fixed at some point.
          */
-        generateTrg1MemSrc1Instruction(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), oldValueReg);
+        Inst_Trg1MemSrc1(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), oldValueReg);
     } else {
         int64_t value = 0;
         bool negate = false;
@@ -7776,29 +7754,27 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
         TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        Inst_Label(cg, OP::label, node, loopLabel);
 
         // load acquire exclusive register
         auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
-        generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
+        Inst_Trg1Mem(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
         if (valueReg == NULL) {
             if (!negate) {
-                generateTrg1Src1ImmInstruction(cg, (is64Bit ? OP::addimmx : OP::addimmw), node, newValueReg,
-                    oldValueReg, value);
+                Inst_Trg1Src1Imm(cg, (is64Bit ? OP::addimmx : OP::addimmw), node, newValueReg, oldValueReg, value);
             } else {
-                generateTrg1Src1ImmInstruction(cg, (is64Bit ? OP::subimmx : OP::subimmw), node, newValueReg,
-                    oldValueReg, -value);
+                Inst_Trg1Src1Imm(cg, (is64Bit ? OP::subimmx : OP::subimmw), node, newValueReg, oldValueReg, -value);
             }
         } else {
-            generateTrg1Src2Instruction(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
+            Inst_Trg1Src2(cg, (is64Bit ? OP::addx : OP::addw), node, newValueReg, oldValueReg, valueReg);
         }
         // store release exclusive register
         auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
-        generateTrg1MemSrc1Instruction(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), newValueReg);
-        generateCompareBranchInstruction(cg, OP::cbnzx, node, tempReg, loopLabel);
+        Inst_Trg1MemSrc1(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), newValueReg);
+        Inst_CompareBranch(cg, OP::cbnzx, node, tempReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         const int numDeps = (valueReg != NULL) ? 5 : 4;
@@ -7813,7 +7789,7 @@ TR::Register *intrinsicAtomicFetchAndAdd(TR::Node *node, TR::CodeGenerator *cg)
         }
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+        Inst_Label(cg, OP::label, node, doneLabel, conditions);
 
         cg->stopUsingRegister(newValueReg);
         cg->stopUsingRegister(tempReg);
@@ -7872,7 +7848,7 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
          * convention is somewhat confusing. Its `treg` register actually is a source register and `sreg` register is a
          * target register. This needs to be fixed at some point.
          */
-        generateTrg1MemSrc1Instruction(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), oldValueReg);
+        Inst_Trg1MemSrc1(cg, op, node, valueReg, MRef_disp(cg, addressReg, 0), oldValueReg);
     } else {
         /*
          * Generating non-intuitive instruction sequence which uses load exclusive register
@@ -7899,18 +7875,18 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
         TR::LabelSymbol *loopLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
         loopLabel->setStartInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, loopLabel);
+        Inst_Label(cg, OP::label, node, loopLabel);
 
         // load acquire exclusive register
         auto loadop = is64Bit ? OP::ldxrx : OP::ldxrw;
-        generateTrg1MemInstruction(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
+        Inst_Trg1Mem(cg, loadop, node, oldValueReg, MRef_disp(cg, addressReg, 0));
 
         // store release exclusive register
         auto storeop = is64Bit ? OP::stlxrx : OP::stlxrw;
-        generateTrg1MemSrc1Instruction(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), valueReg);
-        generateCompareBranchInstruction(cg, OP::cbnzx, node, tempReg, loopLabel);
+        Inst_Trg1MemSrc1(cg, storeop, node, tempReg, MRef_disp(cg, addressReg, 0), valueReg);
+        Inst_CompareBranch(cg, OP::cbnzx, node, tempReg, loopLabel);
 
-        generateSynchronizationInstruction(cg, OP::dmb, node, OP::ish);
+        Inst_Synchronization(cg, OP::dmb, node, OP::ish);
 
         // Set the conditions and dependencies
         auto conditions = RegDeps(0, 4, cg);
@@ -7921,7 +7897,7 @@ TR::Register *intrinsicAtomicSwap(TR::Node *node, TR::CodeGenerator *cg)
         conditions->addPostCondition(tempReg, TR::RealRegister::NoReg);
 
         doneLabel->setEndInternalControlFlow();
-        generateLabelInstruction(cg, OP::label, node, doneLabel, conditions);
+        Inst_Label(cg, OP::label, node, doneLabel, conditions);
 
         cg->stopUsingRegister(tempReg);
     }

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -104,7 +104,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeG
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
-    generateNegInstruction(cg, node, trgReg, srcReg);
+    Inst_Neg(cg, node, trgReg, srcReg);
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
     return trgReg;
@@ -115,7 +115,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
     TR::Node *child = node->getFirstChild();
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
-    generateNegInstruction(cg, node, trgReg, srcReg, true);
+    Inst_Neg(cg, node, trgReg, srcReg, true);
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
     return trgReg;
@@ -134,7 +134,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::inlineVectorUnaryOp(TR::Node *node, TR:
     if (evaluatorHelper != NULL) {
         (*evaluatorHelper)(node, resReg, srcReg, cg);
     } else {
-        generateTrg1Src1Instruction(cg, op, node, resReg, srcReg);
+        Inst_Trg1Src1(cg, op, node, resReg, srcReg);
     }
     cg->decReferenceCount(firstChild);
     return resReg;
@@ -256,9 +256,9 @@ static TR::Register *commonIntegerAbsEvaluator(TR::Node *node, TR::CodeGenerator
     OP::Mnemonic eorOp = is64bit ? OP::eorx : OP::eorw;
     OP::Mnemonic subOp = is64bit ? OP::subx : OP::subw;
 
-    generateArithmeticShiftRightImmInstruction(cg, node, tempReg, reg, is64bit ? 63 : 31, is64bit);
-    generateTrg1Src2Instruction(cg, eorOp, node, reg, reg, tempReg);
-    generateTrg1Src2Instruction(cg, subOp, node, reg, reg, tempReg);
+    Inst_ArithmeticShiftRightImm(cg, node, tempReg, reg, is64bit ? 63 : 31, is64bit);
+    Inst_Trg1Src2(cg, eorOp, node, reg, reg, tempReg);
+    Inst_Trg1Src2(cg, subOp, node, reg, reg, tempReg);
 
     cg->stopUsingRegister(tempReg);
     node->setRegister(reg);
@@ -282,7 +282,7 @@ static TR::Register *commonUnaryHelper(TR::Node *node, OP::Mnemonic op, TR::Code
     TR::Register *srcReg = cg->evaluate(child);
     TR::Register *trgReg = (child->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
 
-    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, srcReg);
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
     return trgReg;
@@ -291,7 +291,7 @@ static TR::Register *commonUnaryHelper(TR::Node *node, OP::Mnemonic op, TR::Code
 TR::Register *OMR::ARM64::TreeEvaluator::sbyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Register *trgReg = commonUnaryHelper(node, OP::rev16w, cg);
-    generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, trgReg, 15); // sign extension
+    Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, trgReg, 15); // sign extension
     return trgReg;
 }
 
@@ -317,19 +317,19 @@ static TR::Register *hbitHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     OP::Mnemonic op;
 
     op = is64bit ? OP::clzx : OP::clzw;
-    generateTrg1Src1Instruction(cg, op, node, tmpReg, srcReg);
-    generateCompareImmInstruction(cg, node, srcReg, 0, is64bit);
+    Inst_Trg1Src1(cg, op, node, tmpReg, srcReg);
+    Inst_CompareImm(cg, node, srcReg, 0, is64bit);
     if (is64bit) {
         // mov trgReg, #0x80000000
-        generateTrg1ImmInstruction(cg, OP::movzx, node, trgReg, 0x8000 | TR::MOV_LSL48);
+        Inst_Trg1Imm(cg, OP::movzx, node, trgReg, 0x8000 | TR::MOV_LSL48);
     } else {
         // mov trgReg, #0x8000000000000000
-        generateTrg1ImmInstruction(cg, OP::movzw, node, trgReg, 0x8000 | TR::MOV_LSL16);
+        Inst_Trg1Imm(cg, OP::movzw, node, trgReg, 0x8000 | TR::MOV_LSL16);
     }
     op = is64bit ? OP::cselx : OP::cselw;
-    generateCondTrg1Src2Instruction(cg, op, node, trgReg, trgReg, srcReg, TR::CC_NE);
+    Inst_CondTrg1Src2(cg, op, node, trgReg, trgReg, srcReg, TR::CC_NE);
     op = is64bit ? OP::lsrvx : OP::lsrvw;
-    generateTrg1Src2Instruction(cg, op, node, trgReg, trgReg, tmpReg);
+    Inst_Trg1Src2(cg, op, node, trgReg, trgReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -360,8 +360,8 @@ static TR::Register *lbitHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     OP::Mnemonic op = is64bit ? OP::andx : OP::andw;
 
     // x & -x
-    generateNegInstruction(cg, node, tmpReg, srcReg, is64bit);
-    generateTrg1Src2Instruction(cg, op, node, trgReg, srcReg, tmpReg);
+    Inst_Neg(cg, node, tmpReg, srcReg, is64bit);
+    Inst_Trg1Src2(cg, op, node, trgReg, srcReg, tmpReg);
 
     cg->stopUsingRegister(tmpReg);
 
@@ -404,9 +404,9 @@ static TR::Register *notzHelper(TR::Node *node, bool is64bit, TR::CodeGenerator 
     OP::Mnemonic op;
 
     op = is64bit ? OP::rbitx : OP::rbitw;
-    generateTrg1Src1Instruction(cg, op, node, trgReg, srcReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, srcReg);
     op = is64bit ? OP::clzx : OP::clzw;
-    generateTrg1Src1Instruction(cg, op, node, trgReg, trgReg);
+    Inst_Trg1Src1(cg, op, node, trgReg, trgReg);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
@@ -434,14 +434,14 @@ static TR::Register *popcntHelper(TR::Node *node, bool is64bit, TR::CodeGenerato
     TR::Register *tmpReg = cg->allocateRegister(TR_VRF);
 
     if (is64bit) {
-        generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, tmpReg, srcReg);
+        Inst_Trg1Src1(cg, OP::fmov_xtod, node, tmpReg, srcReg);
     } else {
-        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, node, trgReg, srcReg, 31); // zero extension
-        generateTrg1Src1Instruction(cg, OP::fmov_xtod, node, tmpReg, trgReg);
+        Inst_Trg1Src1Imm(cg, OP::ubfmx, node, trgReg, srcReg, 31); // zero extension
+        Inst_Trg1Src1(cg, OP::fmov_xtod, node, tmpReg, trgReg);
     }
-    generateTrg1Src1Instruction(cg, OP::vcnt8b, node, tmpReg, tmpReg);
-    generateTrg1Src1Instruction(cg, OP::vaddv8b, node, tmpReg, tmpReg);
-    generateMovVectorElementToGPRInstruction(cg, OP::umovwb, node, trgReg, tmpReg, 0);
+    Inst_Trg1Src1(cg, OP::vcnt8b, node, tmpReg, tmpReg);
+    Inst_Trg1Src1(cg, OP::vaddv8b, node, tmpReg, tmpReg);
+    Inst_MovVectorElementToGPR(cg, OP::umovwb, node, trgReg, tmpReg, 0);
 
     cg->stopUsingRegister(tmpReg);
     node->setRegister(trgReg);
@@ -486,7 +486,7 @@ static TR::Register *x2iHelper(TR::Node *node, TR::CodeGenerator *cg, bool isB2i
         TR::Node *intChild = child->getFirstChild();
         srcReg = cg->evaluate(intChild);
         trgReg = (intChild->getReferenceCount() == 1) ? srcReg : cg->allocateRegister();
-        generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
+        Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
         node->setRegister(trgReg);
         cg->decReferenceCount(intChild);
         cg->decReferenceCount(child);
@@ -496,10 +496,10 @@ static TR::Register *x2iHelper(TR::Node *node, TR::CodeGenerator *cg, bool isB2i
         if (child->getOpCodeValue() == childOp2 || child->getOpCodeValue() == childOp3) {
             // No sign extension needed.
             if (trgReg != srcReg) {
-                generateMovInstruction(cg, node, trgReg, srcReg);
+                Inst_Mov(cg, node, trgReg, srcReg);
             }
         } else {
-            generateTrg1Src1ImmInstruction(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
+            Inst_Trg1Src1Imm(cg, OP::sbfmw, node, trgReg, srcReg, sbfmBit);
         }
         node->setRegister(trgReg);
         cg->decReferenceCount(child);
@@ -526,7 +526,7 @@ static TR::Register *extendToIntOrLongHelper(TR::Node *node, OP::Mnemonic op, ui
     // signed extension: alias of SBFM
     // unsigned extension: alias of UBFM
     TR_ASSERT_FATAL(imms < 32, "Extension size too big");
-    generateTrg1Src1ImmInstruction(cg, op, node, trgReg, srcReg, imms);
+    Inst_Trg1Src1Imm(cg, op, node, trgReg, srcReg, imms);
 
     node->setRegister(trgReg);
     cg->decReferenceCount(child);
@@ -601,10 +601,10 @@ TR::Register *OMR::ARM64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeG
     if (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi) {
         // No need for zero extension
         if (trgReg != srcReg) {
-            generateMovInstruction(cg, node, trgReg, srcReg);
+            Inst_Mov(cg, node, trgReg, srcReg);
         }
     } else {
-        generateTrg1Src1ImmInstruction(cg, OP::ubfmx, node, trgReg, srcReg, 31);
+        Inst_Trg1Src1Imm(cg, OP::ubfmx, node, trgReg, srcReg, 31);
     }
     node->setRegister(trgReg);
     cg->decReferenceCount(child);


### PR DESCRIPTION
This commit introduces new functions `Inst_*()` for generating AArch64 instructions, and replaces `generate*Instruction()` for improving code readability.

It also removes `generateTrgInstruction()` and `generateCondTrg1Src2Instruction()` with register dependencies, which are
no longer needed.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>